### PR TITLE
Handle more controlled mob commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,13 @@ dependencies {
     //implementation fg.deobf("curse.maven:geckolib-388172:6027567")
     //implementation fg.deobf("curse.maven:born-in-chaos-686437:6193155")
     //implementation fg.deobf("curse.maven:rpgz-404828:5549878")
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 // Example for how to get properties into the manifest for reading at runtime.

--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -736,6 +736,44 @@ public class CommandEvents {
                     mob.getNavigation().moveTo(pos.getX() + 0.5D, pos.getY(), pos.getZ() + 0.5D, 1.0D);
                 }
             }
+            case 3 -> {
+                nbt.putInt("FollowState", 3);
+                if (nbt.contains("HoldX") && nbt.contains("HoldY") && nbt.contains("HoldZ")) {
+                    double x = nbt.getDouble("HoldX");
+                    double y = nbt.getDouble("HoldY");
+                    double z = nbt.getDouble("HoldZ");
+                    mob.getNavigation().moveTo(x, y, z, 1.0D);
+                }
+            }
+            case 5 -> nbt.putInt("FollowState", 5);
+            case 7 -> {
+                Vec3 forward = player.getForward();
+                Vec3 pos = player.position().add(forward.scale(10));
+                BlockPos blockPos = FormationUtils.getPositionOrSurface(
+                        player.getCommandSenderWorld(),
+                        new BlockPos((int) pos.x, (int) pos.y, (int) pos.z)
+                );
+                Vec3 tPos = new Vec3(pos.x, blockPos.getY(), pos.z);
+                nbt.putInt("FollowState", 3);
+                nbt.putDouble("HoldX", tPos.x);
+                nbt.putDouble("HoldY", tPos.y);
+                nbt.putDouble("HoldZ", tPos.z);
+                mob.getNavigation().moveTo(tPos.x, tPos.y, tPos.z, 1.0D);
+            }
+            case 8 -> {
+                Vec3 forward = player.getForward();
+                Vec3 pos = player.position().add(forward.scale(-10));
+                BlockPos blockPos = FormationUtils.getPositionOrSurface(
+                        player.getCommandSenderWorld(),
+                        new BlockPos((int) pos.x, (int) pos.y, (int) pos.z)
+                );
+                Vec3 tPos = new Vec3(pos.x, blockPos.getY(), pos.z);
+                nbt.putInt("FollowState", 3);
+                nbt.putDouble("HoldX", tPos.x);
+                nbt.putDouble("HoldY", tPos.y);
+                nbt.putDouble("HoldZ", tPos.z);
+                mob.getNavigation().moveTo(tPos.x, tPos.y, tPos.z, 1.0D);
+            }
         }
     }
 }

--- a/src/test/java/com/talhanation/recruits/CommandEventsTest.java
+++ b/src/test/java/com/talhanation/recruits/CommandEventsTest.java
@@ -1,0 +1,113 @@
+package com.talhanation.recruits;
+
+import com.talhanation.recruits.util.FormationUtils;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class CommandEventsTest {
+
+    private static void invokeMovement(Mob mob, int state, ServerPlayer player) throws Exception {
+        Method m = CommandEvents.class.getDeclaredMethod("applyControlledMobMovement", Mob.class, int.class, ServerPlayer.class);
+        m.setAccessible(true);
+        m.invoke(null, mob, state, player);
+    }
+
+    @Test
+    public void testState3Return() throws Exception {
+        Mob mob = mock(Mob.class);
+        PathNavigation nav = mock(PathNavigation.class);
+        when(mob.getNavigation()).thenReturn(nav);
+        CompoundTag tag = new CompoundTag();
+        when(mob.getPersistentData()).thenReturn(tag);
+        tag.putDouble("HoldX", 5.0);
+        tag.putDouble("HoldY", 64.0);
+        tag.putDouble("HoldZ", 6.0);
+
+        ServerPlayer player = mock(ServerPlayer.class);
+
+        invokeMovement(mob, 3, player);
+
+        assertEquals(3, tag.getInt("FollowState"));
+        verify(nav).moveTo(5.0, 64.0, 6.0, 1.0D);
+    }
+
+    @Test
+    public void testState5Protect() throws Exception {
+        Mob mob = mock(Mob.class);
+        when(mob.getNavigation()).thenReturn(mock(PathNavigation.class));
+        CompoundTag tag = new CompoundTag();
+        when(mob.getPersistentData()).thenReturn(tag);
+        ServerPlayer player = mock(ServerPlayer.class);
+
+        invokeMovement(mob, 5, player);
+
+        assertEquals(5, tag.getInt("FollowState"));
+    }
+
+    @Test
+    public void testState7Forward() throws Exception {
+        Mob mob = mock(Mob.class);
+        PathNavigation nav = mock(PathNavigation.class);
+        when(mob.getNavigation()).thenReturn(nav);
+        CompoundTag tag = new CompoundTag();
+        when(mob.getPersistentData()).thenReturn(tag);
+        when(mob.position()).thenReturn(Vec3.ZERO);
+
+        ServerPlayer player = mock(ServerPlayer.class);
+        when(player.getForward()).thenReturn(new Vec3(1, 0, 0));
+        when(player.position()).thenReturn(Vec3.ZERO);
+        when(player.getCommandSenderWorld()).thenReturn(mock(ServerLevel.class));
+
+        try (MockedStatic<FormationUtils> utils = mockStatic(FormationUtils.class)) {
+            utils.when(() -> FormationUtils.getPositionOrSurface(any(), any())).thenReturn(new BlockPos(10, 64, 0));
+
+            invokeMovement(mob, 7, player);
+        }
+
+        assertEquals(3, tag.getInt("FollowState"));
+        assertEquals(10.0, tag.getDouble("HoldX"));
+        assertEquals(64.0, tag.getDouble("HoldY"));
+        assertEquals(0.0, tag.getDouble("HoldZ"));
+        verify(nav).moveTo(10.0, 64.0, 0.0, 1.0D);
+    }
+
+    @Test
+    public void testState8Backward() throws Exception {
+        Mob mob = mock(Mob.class);
+        PathNavigation nav = mock(PathNavigation.class);
+        when(mob.getNavigation()).thenReturn(nav);
+        CompoundTag tag = new CompoundTag();
+        when(mob.getPersistentData()).thenReturn(tag);
+        when(mob.position()).thenReturn(Vec3.ZERO);
+
+        ServerPlayer player = mock(ServerPlayer.class);
+        when(player.getForward()).thenReturn(new Vec3(1, 0, 0));
+        when(player.position()).thenReturn(Vec3.ZERO);
+        when(player.getCommandSenderWorld()).thenReturn(mock(ServerLevel.class));
+
+        try (MockedStatic<FormationUtils> utils = mockStatic(FormationUtils.class)) {
+            utils.when(() -> FormationUtils.getPositionOrSurface(any(), any())).thenReturn(new BlockPos(-10, 64, 0));
+
+            invokeMovement(mob, 8, player);
+        }
+
+        assertEquals(3, tag.getInt("FollowState"));
+        assertEquals(-10.0, tag.getDouble("HoldX"));
+        assertEquals(64.0, tag.getDouble("HoldY"));
+        assertEquals(0.0, tag.getDouble("HoldZ"));
+        verify(nav).moveTo(-10.0, 64.0, 0.0, 1.0D);
+    }
+}


### PR DESCRIPTION
## Summary
- support controlled mob movement states 3, 5, 7 and 8
- move forward/back relative to the owner using pathfinding
- add unit tests for controlled mob movement

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68843a6e1cc083278e6b73d40eedaeae