### PR TITLE
Add adapter for controlled mob formations

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -5,7 +5,9 @@ import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.entities.*;
 import com.talhanation.recruits.inventory.CommandMenu;
 import com.talhanation.recruits.network.*;
+import com.talhanation.recruits.util.FormationMember;
 import com.talhanation.recruits.util.FormationUtils;
+import com.talhanation.recruits.util.MobFormationAdapter;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.nbt.CompoundTag;
@@ -50,8 +52,14 @@ public class CommandEvents {
     //7 = forward
     //8 = backward
     public static void onMovementCommand(ServerPlayer player, List<Mob> recruits, int movementState, int formation) {
-        List<AbstractRecruitEntity> recruitList = new ArrayList<>();
-        for (Mob mob : recruits) if (mob instanceof AbstractRecruitEntity ar) recruitList.add(ar);
+        List<FormationMember> recruitList = new ArrayList<>();
+        for (Mob mob : recruits) {
+            if (mob instanceof FormationMember fm) {
+                recruitList.add(fm);
+            } else {
+                recruitList.add(new MobFormationAdapter(mob));
+            }
+        }
 
         if(formation != 0 && (movementState == 2|| movementState == 4 || movementState == 6 || movementState == 7 || movementState == 8)) {
             Vec3 targetPos = null;
@@ -156,16 +164,16 @@ public class CommandEvents {
         }
     }
 
-    private static double getForwardScale(List<AbstractRecruitEntity> recruits) {
-        for (AbstractRecruitEntity recruit : recruits){
-            if(recruit instanceof CaptainEntity) return getForwardScale(recruit);
+    private static double getForwardScale(List<FormationMember> recruits) {
+        for (FormationMember member : recruits){
+            if(member.getMob() instanceof CaptainEntity recruit) return getForwardScale(recruit);
         }
         return 10;
     }
     private static double getForwardScale(AbstractRecruitEntity recruit) {
         return (recruit instanceof CaptainEntity captain && captain.smallShipsController.ship != null && captain.smallShipsController.ship.isCaptainDriver()) ? 25 : 10;
     }
-    public static void applyFormation(int formation, List<AbstractRecruitEntity> recruits, ServerPlayer player, Vec3 targetPos) {
+    public static void applyFormation(int formation, List<FormationMember> recruits, ServerPlayer player, Vec3 targetPos) {
         switch (formation){
             case 1 ->{//LINE UP
                 FormationUtils.lineUpFormation(player, recruits, targetPos);
@@ -326,15 +334,22 @@ public class CommandEvents {
 
                 if(targetPosition.distanceToSqr(oldPos) > 50){
 
-                    List<AbstractRecruitEntity> list = Objects.requireNonNull(serverPlayer).getCommandSenderWorld().getEntitiesOfClass(
-                                    AbstractRecruitEntity.class,
+                    List<Mob> list = Objects.requireNonNull(serverPlayer).getCommandSenderWorld().getEntitiesOfClass(
+                                    Mob.class,
                                     serverPlayer.getBoundingBox().inflate(200)
                             );
-                    int[] array = getActiveGroups(serverPlayer);
+                    list.removeIf(m -> {
+                        if(m instanceof AbstractRecruitEntity recruit) {
+                            return Arrays.stream(getActiveGroups(serverPlayer)).noneMatch(x -> recruit.isEffectedByCommand(serverPlayer.getUUID(), x));
+                        }
+                        return !(m.getPersistentData().getBoolean("RecruitControlled") && m.getPersistentData().getBoolean("Owned") && m.getPersistentData().getUUID("Owner").equals(serverPlayer.getUUID()));
+                    });
+                    List<FormationMember> members = new ArrayList<>();
+                    for(Mob m : list) {
+                        if(m instanceof FormationMember fm) members.add(fm); else members.add(new MobFormationAdapter(m));
+                    }
 
-                    list.removeIf(recruit -> Arrays.stream(array).noneMatch(x -> recruit.isEffectedByCommand(serverPlayer.getUUID(), x)));
-
-                    applyFormation(formation, list, serverPlayer, targetPosition);
+                    applyFormation(formation, members, serverPlayer, targetPosition);
                     int[] position = new int[]{(int) targetPosition.x, (int) targetPosition.z};
                     saveFormationPos(serverPlayer, position);
                 }

--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -76,7 +76,9 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public abstract class AbstractRecruitEntity extends AbstractInventoryEntity{
+import com.talhanation.recruits.util.FormationMember;
+
+public abstract class AbstractRecruitEntity extends AbstractInventoryEntity implements FormationMember {
     private static final EntityDataAccessor<Integer> DATA_REMAINING_ANGER_TIME = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> FOLLOW_STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
@@ -893,6 +895,7 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity{
     //4 = hold my position
     //5 = Protect
     //6 = Work
+    @Override
     public void setFollowState(int state){
         switch (state) {
             case 0,6 -> {
@@ -941,6 +944,12 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity{
         this.entityData.set(FOLLOW_STATE, state);
     }
 
+    @Override
+    public Mob getMob() {
+        return this;
+    }
+
+    @Override
     public void setHoldPos(Vec3 holdPos){
         //this.entityData.set(HOLD_POS, Optional.of(holdPos));
         this.holdPosVec = holdPos;

--- a/src/main/java/com/talhanation/recruits/util/FormationMember.java
+++ b/src/main/java/com/talhanation/recruits/util/FormationMember.java
@@ -1,0 +1,24 @@
+package com.talhanation.recruits.util;
+
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Simple interface for mobs that can participate in formations.
+ */
+public interface FormationMember {
+    /**
+     * @return underlying mob entity
+     */
+    Mob getMob();
+
+    /**
+     * Assign the mob's hold position.
+     */
+    void setHoldPos(Vec3 pos);
+
+    /**
+     * Assign the mob's follow state.
+     */
+    void setFollowState(int state);
+}

--- a/src/main/java/com/talhanation/recruits/util/MobFormationAdapter.java
+++ b/src/main/java/com/talhanation/recruits/util/MobFormationAdapter.java
@@ -1,0 +1,34 @@
+package com.talhanation.recruits.util;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Adapter for generic mobs to participate in formations using persistent NBT fields.
+ */
+public class MobFormationAdapter implements FormationMember {
+    private final Mob mob;
+
+    public MobFormationAdapter(Mob mob) {
+        this.mob = mob;
+    }
+
+    @Override
+    public Mob getMob() {
+        return mob;
+    }
+
+    @Override
+    public void setHoldPos(Vec3 pos) {
+        CompoundTag nbt = mob.getPersistentData();
+        nbt.putDouble("HoldX", pos.x);
+        nbt.putDouble("HoldY", pos.y);
+        nbt.putDouble("HoldZ", pos.z);
+    }
+
+    @Override
+    public void setFollowState(int state) {
+        mob.getPersistentData().putInt("FollowState", state);
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `FormationMember` interface and `MobFormationAdapter`
- implement new interface in `AbstractRecruitEntity`
- refactor formation utilities to operate on the new interface
- update command and network handlers to use adapters when arranging formations

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68843a6f830883278410e2b60f8abbc9