### PR TITLE
Add JDK 17 build requirement note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ Recruit and command villagers, manage armies through custom GUIs, enjoy PvP and 
 https://www.curseforge.com/minecraft/mc-mods/recruits
 
 All Rights Reserved unless otherwise explicitly stated.
+
+## Building
+Gradle 8.1.1 and Groovy 3.0.15 require running the build with JDK 17.
+Switch your JDK with `mise shell java@17.0.2` before executing Gradle tasks.


### PR DESCRIPTION
## Summary
- document that Gradle 8.1.1 with Groovy 3.0.15 requires JDK 17
- show how to switch JDKs with `mise shell java@17.0.2`

## Testing
- `mise shell java@17.0.2`
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_68843f56c3648327ae919b26710bfab1