### PR TITLE
Add ControlledMobScreen

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
@@ -1,0 +1,40 @@
+package com.talhanation.recruits.client.gui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.talhanation.recruits.Main;
+import com.talhanation.recruits.inventory.ControlledMobMenu;
+import de.maxhenkel.corelib.inventory.ScreenBase;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.api.distmarker.OnlyIn;
+
+@OnlyIn(Dist.CLIENT)
+public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
+    private static final ResourceLocation RESOURCE_LOCATION = new ResourceLocation(Main.MOD_ID, "textures/gui/recruit_gui.png");
+
+    private final Mob mob;
+
+    public ControlledMobScreen(ControlledMobMenu container, Inventory playerInventory, Component title) {
+        super(RESOURCE_LOCATION, container, playerInventory, Component.literal(""));
+        this.mob = container.getMob();
+        imageWidth = 176;
+        imageHeight = 223;
+    }
+
+    @Override
+    protected void renderBg(GuiGraphics guiGraphics, float partialTicks, int mouseX, int mouseY) {
+        super.renderBg(guiGraphics, partialTicks, mouseX, mouseY);
+
+        RenderSystem.clearColor(1.0F, 1.0F, 1.0F, 1.0F);
+        int i = (this.width - this.imageWidth) / 2;
+        int j = (this.height - this.imageHeight) / 2;
+
+        InventoryScreen.renderEntityInInventoryFollowsMouse(guiGraphics, i + 50, j + 82, 30,
+                (float) (i + 50) - mouseX, (float) (j + 75 - 50) - mouseY, this.mob);
+    }
+}

--- a/src/main/java/com/talhanation/recruits/init/ModScreens.java
+++ b/src/main/java/com/talhanation/recruits/init/ModScreens.java
@@ -33,7 +33,7 @@ public class ModScreens {
 
     public static void registerMenus() {
         registerMenu(RECRUIT_CONTAINER_TYPE.get(), RecruitInventoryScreen::new);
-        registerMenu(CONTROLLED_MOB_CONTAINER_TYPE.get(), RecruitInventoryScreen::new);
+        registerMenu(CONTROLLED_MOB_CONTAINER_TYPE.get(), ControlledMobScreen::new);
         registerMenu(DEBUG_CONTAINER_TYPE.get(), DebugInvScreen::new);
         registerMenu(COMMAND_CONTAINER_TYPE.get(), CommandScreen::new);
         registerMenu(ASSASSIN_CONTAINER_TYPE.get(), AssassinLeaderScreen::new);

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -92,11 +92,15 @@ public class ControlledMobMenu extends ContainerBase {
         super(ModScreens.CONTROLLED_MOB_CONTAINER_TYPE.get(), id, playerInventory, container);
         this.mob = mob;
         this.mobInventory = container;
-        
+
         addPlayerInventorySlots();
         addMobHandSlots();
         addMobEquipmentSlots();
         addMobInventorySlots();
+    }
+
+    public Mob getMob(){
+        return mob;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- implement `ControlledMobScreen` for controlled mob inventories
- expose mob getter in `ControlledMobMenu`
- hook new screen in `ModScreens.registerMenus`

## Testing
- `./gradlew test` *(fails: CommandEventsTest)*

------
https://chatgpt.com/codex/tasks/task_e_688440d4c0808327b88176d2c6d17d2e