### PR TITLE
Improve controlled mob behaviour

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -388,21 +388,8 @@ public class RecruitEvents {
         Entity entity = event.getEntity();
         if(entity instanceof Mob mob && !(mob instanceof AbstractRecruitEntity)) {
             if(TeamEvents.isControlledMob(mob.getType())) {
-                if(RecruitsServerConfig.ReplaceMobAI.get()) {
-                    try {
-                        java.lang.reflect.Field f = mob.goalSelector.getClass().getDeclaredField("availableGoals");
-                        f.setAccessible(true);
-                        ((java.util.Set<?>)f.get(mob.goalSelector)).clear();
-                        ((java.util.Set<?>)f.get(mob.targetSelector)).clear();
-                    } catch (Exception ignored) {}
-                }
-
                 if (mob instanceof PathfinderMob pathfinderMob) {
-                    pathfinderMob.goalSelector.addGoal(8, new net.minecraft.world.entity.ai.goal.RandomStrollGoal(pathfinderMob, 1.0D));
-                    pathfinderMob.goalSelector.addGoal(9, new net.minecraft.world.entity.ai.goal.LookAtPlayerGoal(pathfinderMob, Player.class, 8.0F));
-                    pathfinderMob.goalSelector.addGoal(10, new net.minecraft.world.entity.ai.goal.RandomLookAroundGoal(pathfinderMob));
-                    pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
-                    pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
+                    applyControlledMobGoals(pathfinderMob);
                 }
                 CompoundTag nbt = mob.getPersistentData();
                 nbt.putBoolean("RecruitControlled", true);
@@ -434,14 +421,13 @@ public class RecruitEvents {
                 nbt.putUUID("Owner", player.getUUID());
                 nbt.putInt("FollowState", 1);
                 if (mob instanceof PathfinderMob pathfinderMob) {
-                    pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
-                    pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
+                    applyControlledMobGoals(pathfinderMob);
                 }
                 player.sendSystemMessage(Component.literal("Mob recruited"));
                 event.setCancellationResult(InteractionResult.SUCCESS);
                 event.setCanceled(true);
             }
-        } else if(nbt.contains("Owner") && nbt.getUUID("Owner").equals(player.getUUID()) && player.isCrouching()) {
+        } else if(nbt.contains("Owner") && nbt.getUUID("Owner").equals(player.getUUID())) {
             CommandEvents.openMobInventoryScreen(player, mob);
             event.setCancellationResult(InteractionResult.SUCCESS);
             event.setCanceled(true);
@@ -840,5 +826,22 @@ public class RecruitEvents {
 
     public static MutableComponent TEXT_INTERACT_WARN(String name) {
         return Component.translatable("chat.recruits.text.block_interact_warn", name);
+    }
+
+    private static void applyControlledMobGoals(PathfinderMob pathfinderMob) {
+        if (RecruitsServerConfig.ReplaceMobAI.get()) {
+            try {
+                java.lang.reflect.Field f = pathfinderMob.goalSelector.getClass().getDeclaredField("availableGoals");
+                f.setAccessible(true);
+                ((java.util.Set<?>) f.get(pathfinderMob.goalSelector)).clear();
+                ((java.util.Set<?>) f.get(pathfinderMob.targetSelector)).clear();
+            } catch (Exception ignored) {
+            }
+        }
+        pathfinderMob.goalSelector.addGoal(8, new net.minecraft.world.entity.ai.goal.RandomStrollGoal(pathfinderMob, 1.0D));
+        pathfinderMob.goalSelector.addGoal(9, new net.minecraft.world.entity.ai.goal.LookAtPlayerGoal(pathfinderMob, Player.class, 8.0F));
+        pathfinderMob.goalSelector.addGoal(10, new net.minecraft.world.entity.ai.goal.RandomLookAroundGoal(pathfinderMob));
+        pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
+        pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
     }
 }

--- a/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
+++ b/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
@@ -721,9 +721,9 @@ public class RecruitsServerConfig {
                         If true, replaces existing mob AI when UniversalMobControl is active.
                         Otherwise adds recruit behaviours on top of existing AI.
                         \t(takes effect after restart)
-                        \tdefault: false""")
+                        \tdefault: true""")
                 .worldRestart()
-                .define("ReplaceMobAI", false);
+                .define("ReplaceMobAI", true);
 
         AdditionalGunItems = BUILDER.comment("""
                         Additional gun items from other mods treated as firearms.


### PR DESCRIPTION
## Summary
- allow opening controlled mob GUI without needing to crouch
- reuse recruit AI goals for controlled mobs on spawn and when hired
- replace mob AI by default

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68844eaa20648327b44dbcd5f88a507d