### PR TITLE
Add controlled mob wander logic

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -47,6 +47,7 @@ import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.nbt.ListTag;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobFollowOwnerGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobHoldPosGoal;
+import com.talhanation.recruits.entities.ai.compat.ControlledMobWanderGoal;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.scores.Team;
@@ -898,7 +899,7 @@ public class RecruitEvents {
             } catch (Exception ignored) {
             }
         }
-        pathfinderMob.goalSelector.addGoal(8, new net.minecraft.world.entity.ai.goal.RandomStrollGoal(pathfinderMob, 1.0D));
+        pathfinderMob.goalSelector.addGoal(8, new ControlledMobWanderGoal(pathfinderMob, 1.0D));
         pathfinderMob.goalSelector.addGoal(9, new net.minecraft.world.entity.ai.goal.LookAtPlayerGoal(pathfinderMob, Player.class, 8.0F));
         pathfinderMob.goalSelector.addGoal(10, new net.minecraft.world.entity.ai.goal.RandomLookAroundGoal(pathfinderMob));
         pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobWanderGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobWanderGoal.java
@@ -1,0 +1,35 @@
+package com.talhanation.recruits.entities.ai.compat;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.goal.RandomStrollGoal;
+
+/**
+ * Random wandering goal that respects FollowState for controlled mobs.
+ */
+public class ControlledMobWanderGoal extends RandomStrollGoal {
+    private final PathfinderMob mob;
+
+    public ControlledMobWanderGoal(PathfinderMob mob, double speed) {
+        super(mob, speed);
+        this.mob = mob;
+    }
+
+    @Override
+    public boolean canUse() {
+        CompoundTag nbt = mob.getPersistentData();
+        if (nbt.getBoolean("RecruitControlled") && nbt.getInt("FollowState") != 0) {
+            return false;
+        }
+        return super.canUse();
+    }
+
+    @Override
+    public boolean canContinueToUse() {
+        CompoundTag nbt = mob.getPersistentData();
+        if (nbt.getBoolean("RecruitControlled") && nbt.getInt("FollowState") != 0) {
+            return false;
+        }
+        return super.canContinueToUse();
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ControlledMobWanderGoal` to disable wandering when a controlled mob is ordered to hold position
- apply the new goal in `RecruitEvents`

## Testing
- `./gradlew test` *(fails: unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688afc653fe483278432ffc2a1ce486d