### PR TITLE
Add combat AI to controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -48,6 +48,12 @@ import net.minecraft.nbt.ListTag;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobFollowOwnerGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobHoldPosGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobWanderGoal;
+import com.talhanation.recruits.entities.ai.compat.ControlledMobTargetGoal;
+import net.minecraft.world.entity.ai.goal.MeleeAttackGoal;
+import net.minecraft.world.entity.ai.goal.RangedBowAttackGoal;
+import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
+import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.monster.RangedAttackMob;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.scores.Team;
@@ -904,6 +910,13 @@ public class RecruitEvents {
         pathfinderMob.goalSelector.addGoal(10, new net.minecraft.world.entity.ai.goal.RandomLookAroundGoal(pathfinderMob));
         pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
         pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
+        if (pathfinderMob instanceof RangedAttackMob ranged) {
+            pathfinderMob.goalSelector.addGoal(4, new RangedBowAttackGoal<>(ranged, 1.0D, 20, 15.0F));
+        } else {
+            pathfinderMob.goalSelector.addGoal(4, new MeleeAttackGoal(pathfinderMob, 1.2D, true));
+        }
+        pathfinderMob.targetSelector.addGoal(1, new HurtByTargetGoal(pathfinderMob));
+        pathfinderMob.targetSelector.addGoal(2, new ControlledMobTargetGoal(pathfinderMob));
     }
 
     private static void maybeReplaceRecruit(AbstractRecruitEntity recruit){

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobTargetGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobTargetGoal.java
@@ -1,0 +1,15 @@
+package com.talhanation.recruits.entities.ai.compat;
+
+import com.talhanation.recruits.RecruitEvents;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+
+/**
+ * Target goal for controlled mobs that respects Recruit diplomacy rules.
+ */
+public class ControlledMobTargetGoal extends NearestAttackableTargetGoal<LivingEntity> {
+    public ControlledMobTargetGoal(PathfinderMob mob) {
+        super(mob, LivingEntity.class, 10, true, false, target -> RecruitEvents.canAttack(mob, target));
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ControlledMobTargetGoal` to find valid enemies using recruit diplomacy
- update controlled mob initialization to include melee or ranged attack goals

## Testing
- `./gradlew test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b03b13c948327b3dcc5e47ee24154