### PR TITLE
Fix generic type for ranged bow goal

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -911,7 +911,7 @@ public class RecruitEvents {
         pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
         pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
         if (pathfinderMob instanceof RangedAttackMob ranged) {
-            pathfinderMob.goalSelector.addGoal(4, new RangedBowAttackGoal<>(ranged, 1.0D, 20, 15.0F));
+            pathfinderMob.goalSelector.addGoal(4, new RangedBowAttackGoal<PathfinderMob>((PathfinderMob) ranged, 1.0D, 20, 15.0F));
         } else {
             pathfinderMob.goalSelector.addGoal(4, new MeleeAttackGoal(pathfinderMob, 1.2D, true));
         }


### PR DESCRIPTION
## Summary
- fix compilation failure in `RecruitEvents` by specifying generic type for `RangedBowAttackGoal`

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688b08f2d4d48327a7f1373674dd983c