### PR TITLE
Fix spawn egg mobs auto attacking

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -401,8 +401,9 @@ public class RecruitEvents {
             CompoundTag nbt = mob.getPersistentData();
             if(nbt.getBoolean("RecruitControlled")) {
                 restoreControlledMobInventory(mob);
-            } else if(TeamEvents.isControlledMob(mob.getType())) {
-                initializeControlledMob(mob);
+                if (mob instanceof PathfinderMob pathfinderMob) {
+                    applyControlledMobGoals(pathfinderMob);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- avoid adding recruit AI to new mobs on spawn
- reapply goals only when loading controlled mobs

## Testing
- `./gradlew test --no-daemon` *(fails: Stopping at 'rename' step)*

------
https://chatgpt.com/codex/tasks/task_e_688c49fc925c83278f92d8a5f7d9ee8f