### PR TITLE
Extend role commands to controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/network/MessageRest.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRest.java
@@ -5,6 +5,7 @@ import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -33,9 +34,23 @@ public class MessageRest implements Message<MessageRest> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = context.getSender();
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(100));
-        for (AbstractRecruitEntity recruits : list) {
-                CommandEvents.onRestCommand(serverPlayer, this.player, recruits, group, should);
+        List<Mob> mobs = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(Mob.class,
+                context.getSender().getBoundingBox().inflate(100),
+                m -> {
+                    if (m instanceof AbstractRecruitEntity recruit) {
+                        return recruit.isEffectedByCommand(this.player, group);
+                    }
+                    return m.getPersistentData().getBoolean("RecruitControlled") &&
+                            m.getPersistentData().getBoolean("Owned") &&
+                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
+                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                });
+        for (Mob m : mobs) {
+            if (m instanceof AbstractRecruitEntity recruit) {
+                CommandEvents.onRestCommand(serverPlayer, this.player, recruit, group, should);
+            } else {
+                CommandEvents.onRestCommand(serverPlayer, this.player, m, group, should);
+            }
         }
     }
     public MessageRest fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
@@ -6,6 +6,7 @@ import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -34,10 +35,24 @@ public class MessageUpkeepEntity implements Message<MessageUpkeepEntity> {
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
-                context.getSender().getBoundingBox().inflate(100)
-        ).forEach(recruit -> CommandEvents.onUpkeepCommand(player_uuid, recruit, group, true, target, null));
+        List<Mob> mobs = player.getCommandSenderWorld().getEntitiesOfClass(Mob.class,
+                context.getSender().getBoundingBox().inflate(100),
+                m -> {
+                    if (m instanceof AbstractRecruitEntity recruit) {
+                        return recruit.isEffectedByCommand(player_uuid, group);
+                    }
+                    return m.getPersistentData().getBoolean("RecruitControlled") &&
+                            m.getPersistentData().getBoolean("Owned") &&
+                            m.getPersistentData().getUUID("Owner").equals(player_uuid) &&
+                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                });
+        for (Mob mob : mobs) {
+            if (mob instanceof AbstractRecruitEntity recruit) {
+                CommandEvents.onUpkeepCommand(player_uuid, recruit, group, true, target, null);
+            } else {
+                CommandEvents.onUpkeepCommand(player_uuid, mob, group, true, target, null);
+            }
+        }
     }
 
     public MessageUpkeepEntity fromBytes(FriendlyByteBuf buf) {


### PR DESCRIPTION
## Summary
- extend CommandEvents with support for mobs marked `RecruitControlled`
- apply role commands (aggro, shields, ranged, rest, upkeep) to recruited mobs
- update network messages to target both recruit entities and recruited mobs

## Testing
- `./gradlew test` *(fails: 4 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688cbc2273b48327b922ac67f1ef0d61