### PR TITLE
Add mob renaming support

### DIFF
--- a/src/main/java/com/talhanation/recruits/Main.java
+++ b/src/main/java/com/talhanation/recruits/Main.java
@@ -124,6 +124,7 @@ public class Main {
                 MessageStrategicFire.class,
                 MessageShields.class,
                 MessageDebugGui.class,
+                MessageRenameMob.class,
                 MessageUpkeepEntity.class,
                 MessageClearTarget.class,
                 MessageCreateTeam.class,

--- a/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
@@ -4,8 +4,10 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.inventory.ControlledMobMenu;
+import com.talhanation.recruits.network.MessageRenameMob;
 import de.maxhenkel.corelib.inventory.ScreenBase;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
@@ -14,12 +16,14 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.gui.widget.ExtendedButton;
+import org.lwjgl.glfw.GLFW;
 
 @OnlyIn(Dist.CLIENT)
 public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
     private static final ResourceLocation RESOURCE_LOCATION = new ResourceLocation(Main.MOD_ID, "textures/gui/recruit_gui.png");
 
     private final Mob mob;
+    private EditBox nameField;
 
     public ControlledMobScreen(ControlledMobMenu container, Inventory playerInventory, Component title) {
         super(RESOURCE_LOCATION, container, playerInventory, Component.literal(""));
@@ -31,9 +35,38 @@ public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
     @Override
     protected void init() {
         super.init();
+        Component name = mob.getCustomName() != null ? mob.getCustomName() : mob.getName();
+        nameField = new EditBox(font, leftPos + 5, topPos - 23, 90, 20, name);
+        nameField.setValue(name.getString());
+        nameField.setMaxLength(32);
+        nameField.setBordered(true);
+        addRenderableWidget(nameField);
+        setInitialFocus(nameField);
         addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos, 70, 20,
                 Component.literal("Commands"),
                 button -> CommandEvents.openCommandScreen(minecraft.player)));
+    }
+
+    @Override
+    protected void containerTick() {
+        super.containerTick();
+        if (nameField != null) nameField.tick();
+    }
+
+    @Override
+    public boolean keyPressed(int key, int a, int b) {
+        if (key == GLFW.GLFW_KEY_ESCAPE) {
+            this.onClose();
+            return true;
+        }
+        setFocused(nameField);
+        return nameField.keyPressed(key, a, b) || nameField.canConsumeInput() || super.keyPressed(key, a, b);
+    }
+
+    @Override
+    public void onClose() {
+        super.onClose();
+        Main.SIMPLE_CHANNEL.sendToServer(new MessageRenameMob(mob.getUUID(), nameField.getValue()));
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageRenameMob.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRenameMob.java
@@ -1,0 +1,56 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import de.maxhenkel.corelib.net.Message;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class MessageRenameMob implements Message<MessageRenameMob> {
+
+    private UUID mobId;
+    private String name;
+
+    public MessageRenameMob() {}
+
+    public MessageRenameMob(UUID mobId, String name) {
+        this.mobId = mobId;
+        this.name = name;
+    }
+
+    @Override
+    public Dist getExecutingSide() {
+        return Dist.DEDICATED_SERVER;
+    }
+
+    @Override
+    public void executeServerSide(NetworkEvent.Context context) {
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        player.getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
+                player.getBoundingBox().inflate(16.0D),
+                m -> !(m instanceof AbstractRecruitEntity) &&
+                        m.getPersistentData().getBoolean("RecruitControlled") &&
+                        m.getUUID().equals(this.mobId)
+        ).forEach(mob -> mob.setCustomName(Component.literal(name)));
+    }
+
+    @Override
+    public MessageRenameMob fromBytes(FriendlyByteBuf buf) {
+        this.mobId = buf.readUUID();
+        this.name = buf.readUtf();
+        return this;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeUUID(mobId);
+        buf.writeUtf(name);
+    }
+}


### PR DESCRIPTION
## Summary
- allow renaming of controlled mobs from their inventory screen
- send name changes to the server
- register new `MessageRenameMob` network packet

## Testing
- `./gradlew test` *(fails: CommandEventsTest)*

------
https://chatgpt.com/codex/tasks/task_e_688ce62ad9d48327b03522cd436d6a60