### PR TITLE
Add group dropdown for controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/Main.java
+++ b/src/main/java/com/talhanation/recruits/Main.java
@@ -125,6 +125,7 @@ public class Main {
                 MessageShields.class,
                 MessageDebugGui.class,
                 MessageRenameMob.class,
+                MessageControlledMobGroup.class,
                 MessageUpkeepEntity.class,
                 MessageClearTarget.class,
                 MessageCreateTeam.class,

--- a/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
@@ -4,19 +4,26 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.inventory.ControlledMobMenu;
+import com.talhanation.recruits.network.MessageControlledMobGroup;
 import com.talhanation.recruits.network.MessageRenameMob;
+import com.talhanation.recruits.client.gui.group.RecruitsGroup;
+import com.talhanation.recruits.client.gui.widgets.ScrollDropDownMenu;
 import de.maxhenkel.corelib.inventory.ScreenBase;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.FastColor;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.client.gui.widget.ExtendedButton;
 import org.lwjgl.glfw.GLFW;
+import java.util.UUID;
+import java.util.Comparator;
 
 @OnlyIn(Dist.CLIENT)
 public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
@@ -24,6 +31,9 @@ public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
 
     private final Mob mob;
     private EditBox nameField;
+    private ScrollDropDownMenu<RecruitsGroup> groupSelectionDropDownMenu;
+    private RecruitsGroup currentGroup;
+    private boolean buttonsSet;
 
     public ControlledMobScreen(ControlledMobMenu container, Inventory playerInventory, Component title) {
         super(RESOURCE_LOCATION, container, playerInventory, Component.literal(""));
@@ -51,6 +61,59 @@ public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
     protected void containerTick() {
         super.containerTick();
         if (nameField != null) nameField.tick();
+        if(RecruitInventoryScreen.groups != null && !RecruitInventoryScreen.groups.isEmpty() && !buttonsSet){
+            RecruitInventoryScreen.groups.sort(Comparator.comparingInt(RecruitsGroup::getId));
+            this.currentGroup = getCurrentGroup(mob.getPersistentData().getInt("Group"));
+            groupSelectionDropDownMenu = new ScrollDropDownMenu<>(currentGroup, leftPos + 77, topPos + 114, 93, 12,
+                    RecruitInventoryScreen.groups,
+                    RecruitsGroup::getName,
+                    selected -> {
+                        this.currentGroup = selected;
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageControlledMobGroup(currentGroup.getId(), mob.getUUID()));
+                    }
+            );
+            groupSelectionDropDownMenu.setBgFillSelected(FastColor.ARGB32.color(255, 139, 139, 139));
+            UUID owner = mob.getPersistentData().getUUID("Owner");
+            groupSelectionDropDownMenu.visible = owner != null && owner.equals(Minecraft.getInstance().player.getUUID());
+            addRenderableWidget(groupSelectionDropDownMenu);
+            buttonsSet = true;
+        }
+    }
+
+    private RecruitsGroup getCurrentGroup(int id){
+        for(RecruitsGroup g : RecruitInventoryScreen.groups){
+            if(g.getId() == id) return g;
+        }
+        return null;
+    }
+
+    @Override
+    public void mouseMoved(double x, double y) {
+        if(groupSelectionDropDownMenu != null) groupSelectionDropDownMenu.onMouseMove(x,y);
+        super.mouseMoved(x, y);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if(groupSelectionDropDownMenu != null && groupSelectionDropDownMenu.isMouseOver(mouseX, mouseY)){
+            groupSelectionDropDownMenu.onMouseClick(mouseX, mouseY);
+            return true;
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseScrolled(double x, double y, double d) {
+        if(groupSelectionDropDownMenu != null) groupSelectionDropDownMenu.mouseScrolled(x,y,d);
+        return super.mouseScrolled(x,y,d);
+    }
+
+    @Override
+    public void render(GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTicks) {
+        super.render(guiGraphics, mouseX, mouseY, partialTicks);
+        if(groupSelectionDropDownMenu != null) {
+            groupSelectionDropDownMenu.renderWidget(guiGraphics, mouseX, mouseY, partialTicks);
+        }
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageControlledMobGroup.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageControlledMobGroup.java
@@ -1,0 +1,55 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import de.maxhenkel.corelib.net.Message;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class MessageControlledMobGroup implements Message<MessageControlledMobGroup> {
+    private int group;
+    private UUID mobId;
+
+    public MessageControlledMobGroup() {
+    }
+
+    public MessageControlledMobGroup(int group, UUID mobId) {
+        this.group = group;
+        this.mobId = mobId;
+    }
+
+    @Override
+    public Dist getExecutingSide() {
+        return Dist.DEDICATED_SERVER;
+    }
+
+    @Override
+    public void executeServerSide(NetworkEvent.Context context) {
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        player.getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
+                player.getBoundingBox().inflate(16.0D),
+                m -> !(m instanceof AbstractRecruitEntity) &&
+                        m.getPersistentData().getBoolean("RecruitControlled") &&
+                        m.getUUID().equals(this.mobId)
+        ).forEach(mob -> mob.getPersistentData().putInt("Group", group));
+    }
+
+    @Override
+    public MessageControlledMobGroup fromBytes(FriendlyByteBuf buf) {
+        this.group = buf.readInt();
+        this.mobId = buf.readUUID();
+        return this;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeInt(group);
+        buf.writeUUID(mobId);
+    }
+}


### PR DESCRIPTION
## Summary
- support group assignment for controlled mobs via new screen dropdown
- send new `MessageControlledMobGroup` when group changed
- register the new message

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688cea6a250883278384309a0b99a270