### PR TITLE
Persist controlled mob data

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -8,6 +8,7 @@ import com.talhanation.recruits.entities.MessengerEntity;
 import com.talhanation.recruits.entities.ai.horse.HorseRiddenByRecruitGoal;
 import com.talhanation.recruits.init.ModEntityTypes;
 import com.talhanation.recruits.inventory.PromoteContainer;
+import com.talhanation.recruits.inventory.ControlledMobMenu;
 import com.talhanation.recruits.network.MessageOpenPromoteScreen;
 import com.talhanation.recruits.world.PillagerPatrolSpawn;
 import com.talhanation.recruits.world.RecruitsDiplomacyManager;
@@ -973,6 +974,12 @@ public class RecruitEvents {
         mob.setItemSlot(EquipmentSlot.FEET, getOrEmpty(extra,3));
         mob.setItemSlot(EquipmentSlot.OFFHAND, getOrEmpty(extra,4));
         mob.setItemSlot(EquipmentSlot.MAINHAND, getOrEmpty(extra,5));
+        if(tag.contains("MobData")){
+            CompoundTag data = tag.getCompound("MobData");
+            for(String key : ControlledMobMenu.EXTRA_KEYS){
+                if(data.contains(key)) tag.put(key, data.get(key).copy());
+            }
+        }
     }
 
     private static ItemStack getOrEmpty(ItemStack[] arr, int idx) {
@@ -988,6 +995,7 @@ public class RecruitEvents {
             if (!stack.isEmpty()) mob.spawnAtLocation(stack);
         }
         tag.remove("MobInventory");
+        tag.remove("MobData");
     }
   
 }

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -40,6 +40,13 @@ public class ControlledMobMenu extends ContainerBase {
 
     private static final int INV_SIZE = 15;
     private static final String NBT_KEY = "MobInventory";
+    private static final String DATA_KEY = "MobData";
+    public static final String[] EXTRA_KEYS = new String[]{
+            "FollowState", "HoldX", "HoldY", "HoldZ", "Group", "AggroState",
+            "ShouldBlock", "ShouldRanged", "ShouldRest", "ShouldStrategicFire",
+            "StrategicFireX", "StrategicFireY", "StrategicFireZ", "UpkeepUUID",
+            "UpkeepPosX", "UpkeepPosY", "UpkeepPosZ", "Owner", "Owned", "HireCost"
+    };
 
     private static SimpleContainer loadInventory(Mob mob){
         SimpleContainer inv = new SimpleContainer(INV_SIZE);
@@ -60,6 +67,12 @@ public class ControlledMobMenu extends ContainerBase {
                 }
             }
         }
+        if(tag.contains(DATA_KEY)){
+            CompoundTag data = tag.getCompound(DATA_KEY);
+            for(String key : EXTRA_KEYS){
+                if(data.contains(key)) tag.put(key, data.get(key).copy());
+            }
+        }
         return inv;
     }
 
@@ -76,6 +89,11 @@ public class ControlledMobMenu extends ContainerBase {
             }
         }
         tag.put(NBT_KEY, list);
+        CompoundTag data = new CompoundTag();
+        for(String key : EXTRA_KEYS){
+            if(tag.contains(key)) data.put(key, tag.get(key).copy());
+        }
+        tag.put(DATA_KEY, data);
         mob.setItemSlot(EquipmentSlot.HEAD, mobInventory.getItem(0));
         mob.setItemSlot(EquipmentSlot.CHEST, mobInventory.getItem(1));
         mob.setItemSlot(EquipmentSlot.LEGS, mobInventory.getItem(2));


### PR DESCRIPTION
## Summary
- store extra controlled mob data alongside MobInventory in a new `MobData` tag
- restore that saved data when mobs load
- remove the tag when mobs drop inventory

## Testing
- `./gradlew test` *(fails: Plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d03d592c083279394b04389241c34