### PR TITLE
Add controlled mob stats screen update

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -343,6 +343,13 @@ public class CommandEvents {
     public static void openMobInventoryScreen(Player player, Mob mob){
         if(player instanceof ServerPlayer serverPlayer){
             updateRecruitInventoryScreen(serverPlayer);
+            CompoundTag nbt = new CompoundTag();
+            CompoundTag data = mob.getPersistentData();
+            if (data.contains("Xp")) nbt.putInt("Xp", data.getInt("Xp"));
+            if (data.contains("Level")) nbt.putInt("Level", data.getInt("Level"));
+            if (data.contains("Moral")) nbt.putFloat("Moral", data.getFloat("Moral"));
+            if (data.contains("Hunger")) nbt.putFloat("Hunger", data.getFloat("Hunger"));
+            Main.SIMPLE_CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new MessageControlledMobStats(nbt));
             NetworkHooks.openScreen(serverPlayer, new MenuProvider() {
                 @Override
                 public @NotNull Component getDisplayName() {

--- a/src/main/java/com/talhanation/recruits/Main.java
+++ b/src/main/java/com/talhanation/recruits/Main.java
@@ -126,6 +126,7 @@ public class Main {
                 MessageDebugGui.class,
                 MessageRenameMob.class,
                 MessageControlledMobGroup.class,
+                MessageControlledMobStats.class,
                 MessageUpkeepEntity.class,
                 MessageClearTarget.class,
                 MessageCreateTeam.class,

--- a/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
@@ -5,6 +5,7 @@ import com.talhanation.recruits.Main;
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.inventory.ControlledMobMenu;
 import com.talhanation.recruits.network.MessageControlledMobGroup;
+import com.talhanation.recruits.network.MessageControlledMobStats;
 import com.talhanation.recruits.network.MessageRenameMob;
 import com.talhanation.recruits.client.gui.group.RecruitsGroup;
 import com.talhanation.recruits.client.gui.widgets.ScrollDropDownMenu;
@@ -28,6 +29,12 @@ import java.util.Comparator;
 @OnlyIn(Dist.CLIENT)
 public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
     private static final ResourceLocation RESOURCE_LOCATION = new ResourceLocation(Main.MOD_ID, "textures/gui/recruit_gui.png");
+    private static final int fontColor = 4210752;
+
+    public static int xp;
+    public static int level;
+    public static float morale;
+    public static float hunger;
 
     private final Mob mob;
     private EditBox nameField;
@@ -114,6 +121,27 @@ public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
         if(groupSelectionDropDownMenu != null) {
             groupSelectionDropDownMenu.renderWidget(guiGraphics, mouseX, mouseY, partialTicks);
         }
+    }
+
+    @Override
+    protected void renderLabels(GuiGraphics guiGraphics, int mouseX, int mouseY) {
+        super.renderLabels(guiGraphics, mouseX, mouseY);
+        guiGraphics.pose().pushPose();
+        guiGraphics.pose().scale(0.7F, 0.7F, 1F);
+
+        int k = 112;
+        int l = 32;
+        int gap = 42;
+
+        guiGraphics.drawString(font, "Lvl.:", k, l, fontColor, false);
+        guiGraphics.drawString(font, String.valueOf(level), k + gap, l, fontColor, false);
+        guiGraphics.drawString(font, "Exp.:", k, l + 10, fontColor, false);
+        guiGraphics.drawString(font, String.valueOf(xp), k + gap, l + 10, fontColor, false);
+        guiGraphics.drawString(font, "Morale:", k, l + 20, fontColor, false);
+        guiGraphics.drawString(font, String.valueOf((int) morale), k + gap, l + 20, fontColor, false);
+        guiGraphics.drawString(font, "Hunger:", k, l + 30, fontColor, false);
+        guiGraphics.drawString(font, String.valueOf((int) hunger), k + gap, l + 30, fontColor, false);
+        guiGraphics.pose().popPose();
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/network/MessageControlledMobStats.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageControlledMobStats.java
@@ -1,0 +1,44 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.client.gui.ControlledMobScreen;
+import de.maxhenkel.corelib.net.Message;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.network.NetworkEvent;
+
+public class MessageControlledMobStats implements Message<MessageControlledMobStats> {
+    private CompoundTag nbt;
+
+    public MessageControlledMobStats() {
+    }
+
+    public MessageControlledMobStats(CompoundTag nbt) {
+        this.nbt = nbt;
+    }
+
+    @Override
+    public Dist getExecutingSide() {
+        return Dist.CLIENT;
+    }
+
+    @Override
+    public void executeClientSide(NetworkEvent.Context context) {
+        if (nbt == null) return;
+        ControlledMobScreen.level = nbt.getInt("Level");
+        ControlledMobScreen.xp = nbt.getInt("Xp");
+        ControlledMobScreen.morale = nbt.getFloat("Moral");
+        ControlledMobScreen.hunger = nbt.getFloat("Hunger");
+    }
+
+    @Override
+    public MessageControlledMobStats fromBytes(FriendlyByteBuf buf) {
+        this.nbt = buf.readNbt();
+        return this;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeNbt(nbt);
+    }
+}


### PR DESCRIPTION
## Summary
- show stats for controlled mobs in the GUI
- deliver stats to the client with `MessageControlledMobStats`

## Testing
- `./gradlew build` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_688d03d969908327bf35b7438121bf71