### PR TITLE
Sync controlled mob inventory size with recruit menu

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -8,6 +8,7 @@ import com.talhanation.recruits.entities.MessengerEntity;
 import com.talhanation.recruits.entities.ai.horse.HorseRiddenByRecruitGoal;
 import com.talhanation.recruits.init.ModEntityTypes;
 import com.talhanation.recruits.inventory.PromoteContainer;
+import com.talhanation.recruits.inventory.RecruitInventoryMenu;
 import com.talhanation.recruits.network.MessageOpenPromoteScreen;
 import com.talhanation.recruits.world.PillagerPatrolSpawn;
 import com.talhanation.recruits.world.RecruitsDiplomacyManager;
@@ -959,7 +960,7 @@ public class RecruitEvents {
         CompoundTag tag = mob.getPersistentData();
         if (!tag.contains("MobInventory")) return;
         ListTag list = tag.getList("MobInventory", 10);
-        ItemStack[] extra = new ItemStack[15];
+        ItemStack[] extra = new ItemStack[RecruitInventoryMenu.INV_SIZE];
         for(int i = 0; i < list.size(); i++) {
             CompoundTag ct = list.getCompound(i);
             int slot = ct.getByte("Slot") & 255;

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.inventory;
 
 import com.mojang.datafixers.util.Pair;
 import com.talhanation.recruits.init.ModScreens;
+import com.talhanation.recruits.inventory.RecruitInventoryMenu;
 import de.maxhenkel.corelib.inventory.ContainerBase;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -38,7 +39,7 @@ public class ControlledMobMenu extends ContainerBase {
             EquipmentSlot.MAINHAND
     };
 
-    private static final int INV_SIZE = 15;
+    private static final int INV_SIZE = RecruitInventoryMenu.INV_SIZE;
     private static final String NBT_KEY = "MobInventory";
 
     private static SimpleContainer loadInventory(Mob mob){
@@ -168,9 +169,11 @@ public class ControlledMobMenu extends ContainerBase {
     }
 
     private void addMobInventorySlots(){
-        for(int k=0;k<3;++k){
-            for(int l=0;l<3;++l){
-                this.addSlot(new Slot(mobInventory,6 + l + k * 3, 2 * 18 + 82 + l * 18, 18 + k * 18));
+        int columns = RecruitInventoryMenu.INV_COLUMNS;
+        int rows = (mobInventory.getContainerSize() - 6) / columns;
+        for(int k=0;k<rows;++k){
+            for(int l=0;l<columns;++l){
+                this.addSlot(new Slot(mobInventory,6 + l + k * columns, 2 * 18 + 82 + l * 18, 18 + k * 18));
             }
         }
     }

--- a/src/main/java/com/talhanation/recruits/inventory/RecruitInventoryMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/RecruitInventoryMenu.java
@@ -37,6 +37,10 @@ public class RecruitInventoryMenu extends ContainerBase {
             EquipmentSlot.MAINHAND
     };
 
+    public static final int INV_COLUMNS = 3;
+    public static final int INV_ROWS = 3;
+    public static final int INV_SIZE = 6 + INV_COLUMNS * INV_ROWS;
+
     public RecruitInventoryMenu(int id, AbstractRecruitEntity recruit, Inventory playerInventory) {
         super(ModScreens.RECRUIT_CONTAINER_TYPE.get(), id, playerInventory, recruit.getInventory());
         this.recruit = recruit;


### PR DESCRIPTION
## Summary
- expose recruit inventory size constants
- use recruit inventory constants in ControlledMobMenu and scale layout accordingly
- adjust restoreControlledMobInventory to use new inventory size

## Testing
- `./gradlew test --no-daemon` *(fails: CommandEventsTest failures)*

------
https://chatgpt.com/codex/tasks/task_e_688d03d740d883279d7363944ab929cf