### PR TITLE
Add recruit hunger configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # recruits
 Recruit and command villagers, manage armies through custom GUIs, enjoy PvP and team compatibility, and fully configurable features.
 
+Server configs now allow disabling recruit hunger or defining exactly
+which food items recruits are willing to eat.
+
 https://www.curseforge.com/minecraft/mc-mods/recruits
 
 All Rights Reserved unless otherwise explicitly stated.

--- a/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
+++ b/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
@@ -46,6 +46,8 @@ public class RecruitsServerConfig {
     public static ForgeConfigSpec.ConfigValue<List<List<String>>> NomadStartEquipments;
     public static ForgeConfigSpec.ConfigValue<List<String>> AcceptedDamagesourceImmunity;
     public static ForgeConfigSpec.ConfigValue<List<String>> FoodBlackList;
+    public static ForgeConfigSpec.BooleanValue RecruitHunger;
+    public static ForgeConfigSpec.ConfigValue<List<String>> RecruitFoodList;
     public static ForgeConfigSpec.BooleanValue AggroRecruitsBlockPlaceBreakEvents;
     public static ForgeConfigSpec.BooleanValue NeutralRecruitsBlockPlaceBreakEvents;
     public static ForgeConfigSpec.BooleanValue AggroRecruitsBlockInteractingEvents;
@@ -94,6 +96,8 @@ public class RecruitsServerConfig {
             Arrays.asList("minecraft:creeper", "minecraft:ghast", "minecraft:enderman", "minecraft:zombified_piglin", "corpse:corpse", "minecraft:armorstand"));
     public static ArrayList<String> FOOD_BLACKLIST = new ArrayList<>(
             Arrays.asList("minecraft:poisonous_potato", "minecraft:spider_eye", "minecraft:pufferfish"));
+    public static ArrayList<String> RECRUIT_FOOD = new ArrayList<>(
+            Arrays.asList("minecraft:bread", "minecraft:cooked_beef", "minecraft:cooked_chicken"));
     public static ArrayList<String> MOUNTS = new ArrayList<>(
             Arrays.asList("minecraft:mule", "minecraft:donkey", "minecraft:horse", "minecraft:llama", "minecraft:pig", "minecraft:boat", "minecraft:minecart", "smallships:cog", "smallships:brigg", "smallships:galley", "smallships:drakkar", "camels:camel"));
     public static ArrayList<List<String>> START_EQUIPMENT_RECRUIT = new ArrayList<>(
@@ -178,12 +182,26 @@ public class RecruitsServerConfig {
                 .define("TargetBlackList", TARGET_BLACKLIST);
 
         FoodBlackList = BUILDER.comment("""
-                        
-                        List of foods that recruits should not eat. 
+
+                        List of foods that recruits should not eat.
                         \t(takes effect after restart)
                         \tFood items in this list will not be eaten by recruits and also not be picked up from upkeep.""")
                 .worldRestart()
                 .define("FoodBlackList", FOOD_BLACKLIST);
+
+        RecruitFoodList = BUILDER.comment("""
+                        List of foods recruits are allowed to eat. Leave empty to allow any food item not blacklisted.
+                        \t(takes effect after restart)
+                        default: ["minecraft:bread", "minecraft:cooked_beef", "minecraft:cooked_chicken"]""")
+                .worldRestart()
+                .define("RecruitFoodList", RECRUIT_FOOD);
+
+        RecruitHunger = BUILDER.comment("""
+                        Enable hunger mechanics for recruits.
+                        \t(takes effect after restart)
+                        default: true""")
+                .worldRestart()
+                .define("RecruitHunger", true);
 
         MountWhiteList = BUILDER.comment("""
                         

--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -1395,6 +1395,8 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
     }
 
     public void updateHunger(){
+        if(!RecruitsServerConfig.RecruitHunger.get())
+            return;
         float hunger = getHunger();
 
         if (this.getFollowState() == 2) {
@@ -1422,10 +1424,12 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
     public boolean hasFoodInInv(){
         return this.getInventory().items
                 .stream()
-                .anyMatch(ItemStack::isEdible);
+                .anyMatch(this::canEatItemStack);
     }
 
     public boolean needsToEat(){
+        if(!RecruitsServerConfig.RecruitHunger.get())
+            return false;
         if (getHunger() <= 50F){
             return true;
         }
@@ -1444,10 +1448,14 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
     }
 
     public boolean isStarving(){
+        if(!RecruitsServerConfig.RecruitHunger.get())
+            return false;
         return (getHunger() <= 1F );
     }
 
     public boolean isSaturated(){
+        if(!RecruitsServerConfig.RecruitHunger.get())
+            return true;
         return (getHunger() >= 90F);
     }
 
@@ -2056,6 +2064,10 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
         ResourceLocation location = ForgeRegistries.ITEMS.getKey(stack.getItem());
 
         if(RecruitsServerConfig.FoodBlackList.get().contains(location.toString())){
+            return false;
+        }
+        List<String> allowed = RecruitsServerConfig.RecruitFoodList.get();
+        if(!allowed.isEmpty() && !allowed.contains(location.toString())){
             return false;
         }
         return stack.isEdible();


### PR DESCRIPTION
## Summary
- document new server config options
- add `RecruitHunger` and `RecruitFoodList` configs
- respect new configs in recruit hunger logic

## Testing
- `mise exec java@17 -- ./gradlew test` *(fails: Mockito cannot mock Minecraft classes)*

------
https://chatgpt.com/codex/tasks/task_e_688d095c55dc83278edfc34941afdd78