### PR TITLE
Fix PromoteScreen type check and missing import

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -10,6 +10,7 @@ import com.talhanation.recruits.init.ModEntityTypes;
 import com.talhanation.recruits.inventory.PromoteContainer;
 import com.talhanation.recruits.inventory.PromoteMobContainer;
 import com.talhanation.recruits.inventory.RecruitInventoryMenu;
+import com.talhanation.recruits.inventory.ControlledMobMenu;
 import com.talhanation.recruits.network.MessageOpenPromoteScreen;
 import com.talhanation.recruits.network.MessageOpenControlledMobPromoteScreen;
 import com.talhanation.recruits.world.PillagerPatrolSpawn;

--- a/src/main/java/com/talhanation/recruits/client/gui/PromoteScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/PromoteScreen.java
@@ -66,7 +66,8 @@ public class PromoteScreen extends ScreenBase<PromoteContainer> {
         this.imageWidth = 197;
         this.imageHeight = 250;
         this.player = container.getPlayerEntity();
-        if (container instanceof PromoteMobContainer mobContainer) {
+        Object obj = container;
+        if (obj instanceof PromoteMobContainer mobContainer) {
             this.mob = mobContainer.getMob();
             this.recruit = null;
         } else {


### PR DESCRIPTION
## Summary
- Support PromoteMobContainer in PromoteScreen by using runtime type check
- Import ControlledMobMenu to resolve reference

## Testing
- `./gradlew build` *(fails: RecruitBehaviorTest tests failing)*
- `./gradlew test` *(fails: RecruitBehaviorTest tests failing)*
- `./gradlew check` *(fails: RecruitBehaviorTest tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_688d752c6b348327af97f22737e77451