### PR TITLE
Fix controlled mob friendly fire and formations

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -777,6 +777,16 @@ public class RecruitEvents {
             }
 
             if(targetRecruit instanceof MessengerEntity messenger && messenger.isAtMission()) return false;
+        } else if (attacker instanceof Mob mob && mob.getPersistentData().getBoolean("RecruitControlled")) {
+            CompoundTag attackerNBT = mob.getPersistentData();
+            if (attackerNBT.getBoolean("Owned") && attackerNBT.hasUUID("Owner") && targetRecruit.isOwned() &&
+                    attackerNBT.getUUID("Owner").equals(targetRecruit.getOwnerUUID())) {
+                return false;
+            }
+            if (mob.getTeam() != null && targetRecruit.getTeam() != null &&
+                    mob.getTeam().equals(targetRecruit.getTeam()) && !mob.getTeam().isAllowFriendlyFire()) {
+                return false;
+            }
         }
 
         return canHarmTeam(attacker, targetRecruit);
@@ -792,6 +802,16 @@ public class RecruitEvents {
             if (attackerRecruit.getTeam() != null && mob.getTeam() != null &&
                 attackerRecruit.getTeam().equals(mob.getTeam()) &&
                 !attackerRecruit.getTeam().isAllowFriendlyFire()) {
+                return false;
+            }
+        } else if (attacker instanceof Mob attackerMob && attackerMob.getPersistentData().getBoolean("RecruitControlled")) {
+            CompoundTag attackerNBT = attackerMob.getPersistentData();
+            if (attackerNBT.getBoolean("Owned") && attackerNBT.hasUUID("Owner") && nbt.getBoolean("Owned") && nbt.hasUUID("Owner") &&
+                    attackerNBT.getUUID("Owner").equals(nbt.getUUID("Owner"))) {
+                return false;
+            }
+            if (attackerMob.getTeam() != null && mob.getTeam() != null &&
+                    attackerMob.getTeam().equals(mob.getTeam()) && !attackerMob.getTeam().isAllowFriendlyFire()) {
                 return false;
             }
         }

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobHoldPosGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobHoldPosGoal.java
@@ -25,7 +25,8 @@ public class ControlledMobHoldPosGoal extends Goal {
     public boolean canUse() {
         CompoundTag nbt = mob.getPersistentData();
         if (!nbt.getBoolean("Owned")) return false;
-        if (nbt.getInt("FollowState") != 2) return false;
+        int state = nbt.getInt("FollowState");
+        if (state != 2 && state != 3) return false;
         if (!nbt.contains("HoldX")) {
             nbt.putDouble("HoldX", mob.getX());
             nbt.putDouble("HoldY", mob.getY());


### PR DESCRIPTION
## Summary
- prevent controlled mobs from attacking their owner's allies
- allow controlled mobs to hold formation like recruits

## Testing
- `./gradlew build` *(fails: 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d801738548327924c484b4e61908f