### PR TITLE
Sync mob inventory data to client

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -350,6 +350,11 @@ public class CommandEvents {
             if (data.contains("Moral")) nbt.putFloat("Moral", data.getFloat("Moral"));
             if (data.contains("Hunger")) nbt.putFloat("Hunger", data.getFloat("Hunger"));
             Main.SIMPLE_CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new MessageControlledMobStats(nbt));
+
+            CompoundTag inv = new CompoundTag();
+            if (data.contains("MobInventory")) inv.put("MobInventory", data.getList("MobInventory", 10));
+            if (data.contains("MobData")) inv.put("MobData", data.getCompound("MobData"));
+
             NetworkHooks.openScreen(serverPlayer, new MenuProvider() {
                 @Override
                 public @NotNull Component getDisplayName() {
@@ -358,9 +363,12 @@ public class CommandEvents {
 
                 @Override
                 public @NotNull AbstractContainerMenu createMenu(int i, @NotNull Inventory playerInventory, @NotNull Player p) {
-                    return new ControlledMobMenu(i, mob, playerInventory);
+                    return new ControlledMobMenu(i, mob, playerInventory, inv);
                 }
-            }, buf -> buf.writeUUID(mob.getUUID()));
+            }, buf -> {
+                buf.writeUUID(mob.getUUID());
+                buf.writeNbt(inv);
+            });
         }
     }
     @SubscribeEvent

--- a/src/main/java/com/talhanation/recruits/init/ModScreens.java
+++ b/src/main/java/com/talhanation/recruits/init/ModScreens.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.registries.DeferredRegister;
@@ -70,11 +71,12 @@ public class ModScreens {
         MENU_TYPES.register("controlled_mob_container", () -> IForgeMenuType.create((windowId, inv, data) -> {
             try {
                 UUID mobId = data.readUUID();
+                CompoundTag tag = data.readNbt();
                 Mob mob = getControlledMobByUUID(inv.player, mobId);
                 if (mob == null) {
                     return null;
                 }
-                return new ControlledMobMenu(windowId, mob, inv);
+                return new ControlledMobMenu(windowId, mob, inv, tag);
             } catch (Exception e) {
                 logger.error("Error in controlled_mob_container: ");
                 logger.error(e.getMessage());

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -49,7 +49,7 @@ public class ControlledMobMenu extends ContainerBase {
             "UpkeepPosX", "UpkeepPosY", "UpkeepPosZ", "Owner", "Owned", "HireCost"
     };
 
-    private static SimpleContainer loadInventory(Mob mob){
+    private static SimpleContainer loadInventory(Mob mob, CompoundTag syncTag){
         SimpleContainer inv = new SimpleContainer(INV_SIZE);
         inv.setItem(0, mob.getItemBySlot(EquipmentSlot.HEAD));
         inv.setItem(1, mob.getItemBySlot(EquipmentSlot.CHEST));
@@ -57,7 +57,8 @@ public class ControlledMobMenu extends ContainerBase {
         inv.setItem(3, mob.getItemBySlot(EquipmentSlot.FEET));
         inv.setItem(4, mob.getItemBySlot(EquipmentSlot.OFFHAND));
         inv.setItem(5, mob.getItemBySlot(EquipmentSlot.MAINHAND));
-        CompoundTag tag = mob.getPersistentData();
+
+        CompoundTag tag = syncTag != null ? syncTag : mob.getPersistentData();
         if(tag.contains(NBT_KEY)){
             ListTag list = tag.getList(NBT_KEY, 10);
             for(int i=0;i<list.size();i++){
@@ -71,7 +72,7 @@ public class ControlledMobMenu extends ContainerBase {
         if(tag.contains(DATA_KEY)){
             CompoundTag data = tag.getCompound(DATA_KEY);
             for(String key : EXTRA_KEYS){
-                if(data.contains(key)) tag.put(key, data.get(key).copy());
+                if(data.contains(key)) mob.getPersistentData().put(key, data.get(key).copy());
             }
         }
         return inv;
@@ -104,7 +105,11 @@ public class ControlledMobMenu extends ContainerBase {
     }
 
     public ControlledMobMenu(int id, Mob mob, Inventory playerInventory){
-        this(mob, playerInventory, id, loadInventory(mob));
+        this(mob, playerInventory, id, loadInventory(mob, null));
+    }
+
+    public ControlledMobMenu(int id, Mob mob, Inventory playerInventory, CompoundTag tag){
+        this(mob, playerInventory, id, loadInventory(mob, tag));
     }
 
     private ControlledMobMenu(Mob mob, Inventory playerInventory, int id, Container container){


### PR DESCRIPTION
## Summary
- sync controlled mob inventory and mob data to clients when opening the menu
- load synced data in the controlled mob menu so GUI displays the correct slots
- wire the new data through menu registration and open-screen call

## Testing
- `./gradlew test` *(fails: org.mockito.exceptions.base.MockitoException, NoClassDefFoundError)*
- `./gradlew check` *(fails: org.mockito.exceptions.base.MockitoException, NoClassDefFoundError)*
- `./gradlew build` *(fails: org.mockito.exceptions.base MockitoException, NoClassDefFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_688d850f13b883279a3f6e54b659ef77