### PR TITLE
Sync mob inventory data to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Recruit and command villagers, manage armies through custom GUIs, enjoy PvP and 
 Server configs now allow disabling recruit hunger or defining exactly
 which food items recruits are willing to eat.
 
+### Controlled mobs
+
+Right-click an owned controlled mob to open its inventory and command screen.
+
 https://www.curseforge.com/minecraft/mc-mods/recruits
 
 All Rights Reserved unless otherwise explicitly stated.

--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -1025,6 +1025,7 @@ public class RecruitEvents {
         nbt.putBoolean("Owned", false);
         nbt.putInt("Group", 0);
         nbt.putInt("FollowState", 0);
+        nbt.putInt("AggroState", 3); // passive by default so controlled mobs don't fight
         nbt.putInt("PaymentTimer", AbstractRecruitEntity.getPaymentIntervalTicks());
       
         // initialize fields also used by recruits so that newly controlled mobs

--- a/src/main/java/com/talhanation/recruits/init/ModScreens.java
+++ b/src/main/java/com/talhanation/recruits/init/ModScreens.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.screens.inventory.MenuAccess;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.common.extensions.IForgeMenuType;
 import net.minecraftforge.registries.DeferredRegister;
@@ -70,11 +71,12 @@ public class ModScreens {
         MENU_TYPES.register("controlled_mob_container", () -> IForgeMenuType.create((windowId, inv, data) -> {
             try {
                 UUID mobId = data.readUUID();
+                CompoundTag tag = data.readNbt();
                 Mob mob = getControlledMobByUUID(inv.player, mobId);
                 if (mob == null) {
                     return null;
                 }
-                return new ControlledMobMenu(windowId, mob, inv);
+                return new ControlledMobMenu(windowId, mob, inv, tag);
             } catch (Exception e) {
                 logger.error("Error in controlled_mob_container: ");
                 logger.error(e.getMessage());

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -49,15 +49,10 @@ public class ControlledMobMenu extends ContainerBase {
             "UpkeepPosX", "UpkeepPosY", "UpkeepPosZ", "Owner", "Owned", "HireCost"
     };
 
-    private static SimpleContainer loadInventory(Mob mob){
+    private static SimpleContainer loadInventory(Mob mob, CompoundTag syncTag){
         SimpleContainer inv = new SimpleContainer(INV_SIZE);
-        inv.setItem(0, mob.getItemBySlot(EquipmentSlot.HEAD));
-        inv.setItem(1, mob.getItemBySlot(EquipmentSlot.CHEST));
-        inv.setItem(2, mob.getItemBySlot(EquipmentSlot.LEGS));
-        inv.setItem(3, mob.getItemBySlot(EquipmentSlot.FEET));
-        inv.setItem(4, mob.getItemBySlot(EquipmentSlot.OFFHAND));
-        inv.setItem(5, mob.getItemBySlot(EquipmentSlot.MAINHAND));
-        CompoundTag tag = mob.getPersistentData();
+        CompoundTag tag = syncTag != null ? syncTag : mob.getPersistentData();
+
         if(tag.contains(NBT_KEY)){
             ListTag list = tag.getList(NBT_KEY, 10);
             for(int i=0;i<list.size();i++){
@@ -67,11 +62,20 @@ public class ControlledMobMenu extends ContainerBase {
                     inv.setItem(slot, ItemStack.of(ct));
                 }
             }
+        }else{
+            // fall back to the entity's current equipment when no sync tag is available
+            inv.setItem(0, mob.getItemBySlot(EquipmentSlot.HEAD));
+            inv.setItem(1, mob.getItemBySlot(EquipmentSlot.CHEST));
+            inv.setItem(2, mob.getItemBySlot(EquipmentSlot.LEGS));
+            inv.setItem(3, mob.getItemBySlot(EquipmentSlot.FEET));
+            inv.setItem(4, mob.getItemBySlot(EquipmentSlot.OFFHAND));
+            inv.setItem(5, mob.getItemBySlot(EquipmentSlot.MAINHAND));
         }
+
         if(tag.contains(DATA_KEY)){
             CompoundTag data = tag.getCompound(DATA_KEY);
             for(String key : EXTRA_KEYS){
-                if(data.contains(key)) tag.put(key, data.get(key).copy());
+                if(data.contains(key)) mob.getPersistentData().put(key, data.get(key).copy());
             }
         }
         return inv;
@@ -104,7 +108,11 @@ public class ControlledMobMenu extends ContainerBase {
     }
 
     public ControlledMobMenu(int id, Mob mob, Inventory playerInventory){
-        this(mob, playerInventory, id, loadInventory(mob));
+        this(mob, playerInventory, id, loadInventory(mob, null));
+    }
+
+    public ControlledMobMenu(int id, Mob mob, Inventory playerInventory, CompoundTag tag){
+        this(mob, playerInventory, id, loadInventory(mob, tag));
     }
 
     private ControlledMobMenu(Mob mob, Inventory playerInventory, int id, Container container){


### PR DESCRIPTION
## Summary
- sync controlled mob inventory and mob data to clients when opening the menu
- load synced data in the controlled mob menu so GUI displays the correct slots
- initialize controlled mobs with a passive aggro state so they don't fight each other
- document how to open a controlled mob's inventory
- send equipped items when opening a controlled mob menu and populate client inventory from the transmitted tag

## Testing
- `./gradlew test` *(fails: There were failing tests. See the report at: file:///workspace/mobs_can_be_recruits_too/build/reports/tests/test/index.html)*
- `./gradlew check` *(fails: There were failing tests. See the report at: file:///workspace/mobs_can_be_recruits_too/build/reports/tests/test/index.html)*
- `./gradlew build` *(fails: There were failing tests. See the report at: file:///workspace/mobs_can_be_recruits_too/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_688d850f13b883279a3f6e54b659ef77