### PR TITLE
Fix missing BlunderbussWeapon import

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/RecruitRangedMusketAttackGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/RecruitRangedMusketAttackGoal.java
@@ -1,6 +1,12 @@
 package com.talhanation.recruits.entities.ai.compat;
 
-import com.talhanation.recruits.compat.*;
+import com.talhanation.recruits.compat.BlunderbussWeapon;
+import com.talhanation.recruits.compat.CGMWeapon;
+import com.talhanation.recruits.compat.IWeapon;
+import com.talhanation.recruits.compat.MusketBayonetWeapon;
+import com.talhanation.recruits.compat.MusketScopeWeapon;
+import com.talhanation.recruits.compat.MusketWeapon;
+import com.talhanation.recruits.compat.PistolWeapon;
 import com.talhanation.recruits.entities.CrossBowmanEntity;
 import com.talhanation.recruits.util.AttackUtil;
 import net.minecraft.core.BlockPos;


### PR DESCRIPTION
## Summary
- explicitly import BlunderbussWeapon and related classes

## Testing
- `./gradlew test` *(fails: There were failing tests. See the report at: file:///workspace/mobs_can_be_recruits_too/build/reports/tests/test/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_688da229cf608327af3c97e0b1aff05f