### PR TITLE
Add shared recruit interface for vanilla mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/ControlledMobScreen.java
@@ -91,7 +91,7 @@ public class ControlledMobScreen extends ScreenBase<ControlledMobMenu> {
                     }
             );
             groupSelectionDropDownMenu.setBgFillSelected(FastColor.ARGB32.color(255, 139, 139, 139));
-            UUID owner = mob.getPersistentData().getUUID("Owner");
+            UUID owner = com.talhanation.recruits.entities.IRecruitEntity.of(mob).getOwnerUUID();
             groupSelectionDropDownMenu.visible = owner != null && owner.equals(Minecraft.getInstance().player.getUUID());
             addRenderableWidget(groupSelectionDropDownMenu);
             buttonsSet = true;

--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -78,7 +78,7 @@ import java.util.function.Supplier;
 
 import com.talhanation.recruits.util.FormationMember;
 
-public abstract class AbstractRecruitEntity extends AbstractInventoryEntity implements FormationMember {
+public abstract class AbstractRecruitEntity extends AbstractInventoryEntity implements FormationMember, IRecruitEntity {
     private static final EntityDataAccessor<Integer> DATA_REMAINING_ANGER_TIME = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> FOLLOW_STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
@@ -744,6 +744,10 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
 
     public void setOwnerUUID(Optional<UUID> id) {
         this.entityData.set(OWNER_ID,id);
+    }
+
+    public void setOwnerUUID(@Nullable UUID uuid) {
+        setOwnerUUID(Optional.ofNullable(uuid));
     }
 
     public void setProtectUUID(Optional<UUID> id) {

--- a/src/main/java/com/talhanation/recruits/entities/IRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/IRecruitEntity.java
@@ -1,0 +1,44 @@
+package com.talhanation.recruits.entities;
+
+import net.minecraft.world.entity.Mob;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * Common interface for recruit data shared between {@link AbstractRecruitEntity}
+ * and generic controlled mobs. Provides owner, group and ownership accessors
+ * so logic can operate on either type transparently.
+ */
+public interface IRecruitEntity {
+
+    boolean isOwned();
+
+    void setIsOwned(boolean owned);
+
+    @Nullable
+    UUID getOwnerUUID();
+
+    void setOwnerUUID(@Nullable UUID uuid);
+
+    int getGroup();
+
+    void setGroup(int group);
+
+    /**
+     * Convenience helper to query ownership by UUID.
+     */
+    default boolean isOwnedBy(UUID uuid) {
+        UUID owner = getOwnerUUID();
+        return owner != null && owner.equals(uuid);
+    }
+
+    /**
+     * Obtain a recruit abstraction for the given mob. Recruits implement this
+     * interface directly while other mobs are wrapped in a {@link MobRecruit}.
+     */
+    static IRecruitEntity of(Mob mob) {
+        return mob instanceof IRecruitEntity r ? r : new MobRecruit(mob);
+    }
+}
+

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -1,0 +1,65 @@
+package com.talhanation.recruits.entities;
+
+import net.minecraft.world.entity.Mob;
+import net.minecraft.nbt.CompoundTag;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * Wrapper that exposes recruit-style accessors for vanilla mobs using
+ * their persistent NBT data. This allows command and GUI logic to treat
+ * regular mobs the same as {@link AbstractRecruitEntity} instances.
+ */
+public class MobRecruit implements IRecruitEntity {
+
+    private final Mob mob;
+
+    public MobRecruit(Mob mob) {
+        this.mob = mob;
+    }
+
+    private CompoundTag data() {
+        return mob.getPersistentData();
+    }
+
+    @Override
+    public boolean isOwned() {
+        return data().getBoolean("Owned");
+    }
+
+    @Override
+    public void setIsOwned(boolean owned) {
+        data().putBoolean("Owned", owned);
+    }
+
+    @Nullable
+    @Override
+    public UUID getOwnerUUID() {
+        return data().hasUUID("Owner") ? data().getUUID("Owner") : null;
+    }
+
+    @Override
+    public void setOwnerUUID(@Nullable UUID uuid) {
+        if (uuid == null) {
+            data().remove("Owner");
+        } else {
+            data().putUUID("Owner", uuid);
+        }
+    }
+
+    @Override
+    public int getGroup() {
+        return data().getInt("Group");
+    }
+
+    @Override
+    public void setGroup(int group) {
+        data().putInt("Group", group);
+    }
+
+    public Mob getMob() {
+        return mob;
+    }
+}
+

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobFollowOwnerGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobFollowOwnerGoal.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.entities.ai.compat;
 
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.player.Player;
@@ -28,16 +29,16 @@ public class ControlledMobFollowOwnerGoal extends Goal {
     }
 
     private Player getOwner() {
-        CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.contains("Owner")) return null;
-        UUID id = nbt.getUUID("Owner");
-        return ((ServerLevel) mob.level()).getPlayerByUUID(id);
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        UUID id = recruit.getOwnerUUID();
+        return id == null ? null : ((ServerLevel) mob.level()).getPlayerByUUID(id);
     }
 
     @Override
     public boolean canUse() {
         CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.getBoolean("Owned")) return false;
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!recruit.isOwned()) return false;
         if (nbt.getInt("FollowState") != 1) return false;
         owner = getOwner();
         return owner != null && mob.distanceTo(owner) > startDistance;

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobHoldPosGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobHoldPosGoal.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.entities.ai.compat;
 
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.PathfinderMob;
@@ -24,7 +25,8 @@ public class ControlledMobHoldPosGoal extends Goal {
     @Override
     public boolean canUse() {
         CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.getBoolean("Owned")) return false;
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!recruit.isOwned()) return false;
         int state = nbt.getInt("FollowState");
         if (state != 2 && state != 3) return false;
         if (!nbt.contains("HoldX")) {

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobMeleeAttackGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobMeleeAttackGoal.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.entities.ai.compat;
 
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.ai.goal.MeleeAttackGoal;
 import net.minecraft.world.entity.PathfinderMob;
@@ -17,7 +18,8 @@ public class ControlledMobMeleeAttackGoal extends MeleeAttackGoal {
 
     private boolean isActive() {
         CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.getBoolean("RecruitControlled") || !nbt.getBoolean("Owned"))
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!nbt.getBoolean("RecruitControlled") || !recruit.isOwned())
             return false;
         if (nbt.getBoolean("ShouldRest"))
             return false;

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedBowAttackGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedBowAttackGoal.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.entities.ai.compat;
 
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.monster.RangedAttackMob;
@@ -18,7 +19,8 @@ public class ControlledMobRangedBowAttackGoal<T extends PathfinderMob & RangedAt
 
     private boolean isActive() {
         CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.getBoolean("RecruitControlled") || !nbt.getBoolean("Owned"))
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!nbt.getBoolean("RecruitControlled") || !recruit.isOwned())
             return false;
         if (nbt.getBoolean("ShouldRest"))
             return false;

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRestGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRestGoal.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.entities.ai.compat;
 
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.Goal;
@@ -20,7 +21,8 @@ public class ControlledMobRestGoal extends Goal {
     @Override
     public boolean canUse() {
         CompoundTag nbt = mob.getPersistentData();
-        if (!nbt.getBoolean("RecruitControlled") || !nbt.getBoolean("Owned"))
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!nbt.getBoolean("RecruitControlled") || !recruit.isOwned())
             return false;
         if (!nbt.getBoolean("ShouldRest"))
             return false;

--- a/src/main/java/com/talhanation/recruits/hooks/ControlledMobHooks.java
+++ b/src/main/java/com/talhanation/recruits/hooks/ControlledMobHooks.java
@@ -1,6 +1,7 @@
 package com.talhanation.recruits.hooks;
 
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import com.talhanation.recruits.config.RecruitsServerConfig;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.sounds.SoundEvents;
@@ -55,7 +56,7 @@ public class ControlledMobHooks {
     private void updateMorale(Mob mob, CompoundTag tag) {
         float morale = tag.contains("Moral") ? tag.getFloat("Moral") : 50F;
         float hunger = tag.getFloat("Hunger");
-        boolean owned = tag.getBoolean("Owned");
+        boolean owned = IRecruitEntity.of(mob).isOwned();
 
         if (hunger <= 1F && owned && morale > 0F) {
             morale -= 2F;

--- a/src/main/java/com/talhanation/recruits/network/MessageAggro.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAggro.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -56,10 +57,11 @@ public class MessageAggro implements Message<MessageAggro> {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
                     if (fromGui) return false;
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 }).forEach(m -> {
             if (m instanceof AbstractRecruitEntity recruit) {
                 CommandEvents.onAggroCommand(this.player, recruit, this.state, group, fromGui);

--- a/src/main/java/com/talhanation/recruits/network/MessageClearTarget.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearTarget.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -38,10 +39,11 @@ public class MessageClearTarget implements Message<MessageClearTarget> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(uuid, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(uuid) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(uuid) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob m : mobs) {
             if (m instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageClearUpkeep.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageClearUpkeep.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.world.entity.Mob;
@@ -35,10 +36,11 @@ public class MessageClearUpkeep implements Message<MessageClearUpkeep> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(uuid, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(uuid) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(uuid) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob mob : mobs) {
             if (mob instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageFormationFollowMovement.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageFormationFollowMovement.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import com.talhanation.recruits.util.FormationMember;
 import com.talhanation.recruits.util.MobFormationAdapter;
 import de.maxhenkel.corelib.net.Message;
@@ -42,10 +43,11 @@ public class MessageFormationFollowMovement implements Message<MessageFormationF
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player_uuid, this.group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player_uuid) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player_uuid) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
 
         List<FormationMember> members = new ArrayList<>();

--- a/src/main/java/com/talhanation/recruits/network/MessageMovement.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageMovement.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.world.entity.Mob;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -40,10 +41,11 @@ public class MessageMovement implements Message<MessageMovement> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player_uuid, this.group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player_uuid) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player_uuid) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
 
         CommandEvents.onMovementCommand(context.getSender(), mobs, this.state, this.formation);

--- a/src/main/java/com/talhanation/recruits/network/MessageRangedFire.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRangedFire.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -40,10 +41,11 @@ public class MessageRangedFire implements Message<MessageRangedFire> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob m : mobs) {
             if (m instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageRest.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageRest.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -40,10 +41,11 @@ public class MessageRest implements Message<MessageRest> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob m : mobs) {
             if (m instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageShields.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageShields.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -40,10 +41,11 @@ public class MessageShields implements Message<MessageShields> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
 
         for (Mob mob : mobs) {

--- a/src/main/java/com/talhanation/recruits/network/MessageStrategicFire.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageStrategicFire.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -40,10 +41,11 @@ public class MessageStrategicFire implements Message<MessageStrategicFire> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob mob : mobs) {
             if (mob instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpkeepEntity.java
@@ -3,6 +3,7 @@ package com.talhanation.recruits.network;
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
@@ -41,10 +42,11 @@ public class MessageUpkeepEntity implements Message<MessageUpkeepEntity> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(player_uuid, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(player_uuid) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(player_uuid) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 });
         for (Mob mob : mobs) {
             if (mob instanceof AbstractRecruitEntity recruit) {

--- a/src/main/java/com/talhanation/recruits/network/MessageUpkeepPos.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageUpkeepPos.java
@@ -2,6 +2,7 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -40,10 +41,11 @@ public class MessageUpkeepPos implements Message<MessageUpkeepPos> {
                     if (m instanceof AbstractRecruitEntity recruit) {
                         return recruit.isEffectedByCommand(this.player, group);
                     }
+                    IRecruitEntity recruit = IRecruitEntity.of(m);
                     return m.getPersistentData().getBoolean("RecruitControlled") &&
-                            m.getPersistentData().getBoolean("Owned") &&
-                            m.getPersistentData().getUUID("Owner").equals(this.player) &&
-                            (m.getPersistentData().getInt("Group") == this.group || this.group == 0);
+                            recruit.isOwned() &&
+                            recruit.isOwnedBy(this.player) &&
+                            (recruit.getGroup() == this.group || this.group == 0);
                 }
         ).forEach(m -> {
             if (m instanceof AbstractRecruitEntity recruit) {


### PR DESCRIPTION
## Summary
- allow any Mob to expose recruit-like owner and group data via new `IRecruitEntity`
- use `IRecruitEntity` in recruit events, AI goals and network handlers so controlled mobs share recruit logic

## Testing
- `./gradlew build` *(fails: 7 tests failed)*
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew check` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e28bdb0d083279d010ee328045e87