### PR TITLE
Adjust recruit aggression to defend allies

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -1006,7 +1006,7 @@ public class RecruitEvents {
         recruit.setGroup(0);
         recruit.setOwnerUUID(null);
         nbt.putInt("FollowState", 0);
-        nbt.putInt("AggroState", 3); // passive by default so controlled mobs don't fight
+        nbt.putInt("AggroState", 0); // neutral by default; mobs engage only enemies or threats
         nbt.putInt("PaymentTimer", AbstractRecruitEntity.getPaymentIntervalTicks());
       
         // initialize fields also used by recruits so that newly controlled mobs

--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -1788,7 +1788,7 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
     }
 
     private boolean shouldAttackOnNeutral(LivingEntity target){
-        return isMonster(target) || isAttackingOwnerOrSelf(this, target) || RecruitEvents.isEnemy(this.getTeam(), target.getTeam());
+        return isMonster(target) || isAttackingAlly(this, target) || RecruitEvents.isEnemy(this.getTeam(), target.getTeam());
     }
 
     private boolean shouldAttackOnAggressive(LivingEntity target){
@@ -1799,9 +1799,16 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
         return target instanceof Enemy;
     }
 
-    private boolean isAttackingOwnerOrSelf(AbstractRecruitEntity recruit, LivingEntity target) {
-        return target.getLastHurtByMob() != null &&
-                (target.getLastHurtByMob().equals(recruit) || target.getLastHurtByMob().equals(recruit.getOwner()));
+    private boolean isAttackingAlly(AbstractRecruitEntity recruit, LivingEntity target) {
+        LivingEntity last = target.getLastHurtByMob();
+        if (last == null) return false;
+
+        // target attacked this recruit or its owner
+        if (last.equals(recruit)) return true;
+        if (recruit.isOwned() && last.getUUID().equals(recruit.getOwnerUUID())) return true;
+
+        // attack if the target harmed any allied entity (same team or diplomacy ally)
+        return !RecruitEvents.canHarmTeam(recruit, last);
     }
 
     public boolean isAlliedTo(Entity target) {


### PR DESCRIPTION
## Summary
- Make controlled mobs neutral by default instead of passive
- Attack entities that harm any allied group member or owner

## Testing
- `./gradlew check` *(fails: RecruitBehaviorTest failures)*

------
https://chatgpt.com/codex/tasks/task_e_688e3e06f1e0832795e179957652d7b6