### PR TITLE
feat: add mob recruit interface for AI goals

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -6,6 +6,7 @@ import com.talhanation.recruits.compat.IWeapon;
 import com.talhanation.recruits.config.RecruitsClientConfig;
 import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.entities.ai.*;
+import com.talhanation.recruits.entities.IRecruitMob;
 import com.talhanation.recruits.entities.ai.async.AsyncManager;
 import com.talhanation.recruits.entities.ai.async.AsyncTaskWithCallback;
 import com.talhanation.recruits.entities.ai.compat.BlockWithWeapon;
@@ -78,7 +79,7 @@ import java.util.function.Supplier;
 
 import com.talhanation.recruits.util.FormationMember;
 
-public abstract class AbstractRecruitEntity extends AbstractInventoryEntity implements FormationMember, IRecruitEntity {
+public abstract class AbstractRecruitEntity extends AbstractInventoryEntity implements FormationMember, IRecruitMob {
     private static final EntityDataAccessor<Integer> DATA_REMAINING_ANGER_TIME = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
     private static final EntityDataAccessor<Integer> FOLLOW_STATE = SynchedEntityData.defineId(AbstractRecruitEntity.class, EntityDataSerializers.INT);
@@ -575,6 +576,31 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
 
     public float getMovementSpeed(){
         return (float) this.getAttributeValue(Attributes.MOVEMENT_SPEED);
+    }
+
+    @Override
+    public double getMoveSpeed() {
+        return this.moveSpeed;
+    }
+
+    @Override
+    public boolean getRotate() {
+        return this.rotate;
+    }
+
+    @Override
+    public void setRotate(boolean rotate) {
+        this.rotate = rotate;
+    }
+
+    @Override
+    public float getOwnerRot() {
+        return this.ownerRot;
+    }
+
+    @Override
+    public void setOwnerRot(float rot) {
+        this.ownerRot = rot;
     }
 
     public boolean getFleeing() {

--- a/src/main/java/com/talhanation/recruits/entities/IRecruitMob.java
+++ b/src/main/java/com/talhanation/recruits/entities/IRecruitMob.java
@@ -1,0 +1,102 @@
+package com.talhanation.recruits.entities;
+
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.ai.control.JumpControl;
+import net.minecraft.world.entity.ai.navigation.PathNavigation;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Extension of {@link IRecruitEntity} that exposes gameplay critical state
+ * used by recruit AI goals. It allows vanilla {@link Mob} instances to be
+ * wrapped via {@link MobRecruit} so the same goals can operate on them.
+ */
+public interface IRecruitMob extends IRecruitEntity {
+
+    /**
+     * @return underlying mob instance for this recruit abstraction.
+     */
+    Mob getMob();
+
+    /**
+     * Convenience method mirroring {@link Mob#getCommandSenderWorld()}.
+     */
+    default Level getCommandSenderWorld() {
+        return getMob().level();
+    }
+
+    // --- Inventory helpers ---
+    SimpleContainer getInventory();
+    int getInventorySize();
+    void setBeforeItemSlot(int slot);
+    int getBeforeItemSlot();
+    void resetItemInHand();
+    boolean canEatItemStack(ItemStack stack);
+
+    // --- Hunger and morale ---
+    void updateMorale();
+    void updateHunger();
+    boolean needsToEat();
+    boolean isSaturated();
+    float getHunger();
+    void setHunger(float value);
+    float getMorale();
+    void setMoral(float value);
+
+    // --- State flags ---
+    Vec3 getHoldPos();
+    boolean getShouldHoldPos();
+    boolean getFleeing();
+    boolean needsToGetFood();
+    boolean getShouldMount();
+    double getMoveSpeed();
+    boolean getRotate();
+    void setRotate(boolean rotate);
+    float getOwnerRot();
+    void setOwnerRot(float rot);
+
+    // --- Delegates to the underlying mob ---
+    default ItemStack getOffhandItem() {
+        return getMob().getOffhandItem();
+    }
+
+    default void setItemInHand(InteractionHand hand, ItemStack stack) {
+        getMob().setItemInHand(hand, stack);
+    }
+
+    default void startUsingItem(InteractionHand hand) {
+        getMob().startUsingItem(hand);
+    }
+
+    default void stopUsingItem() {
+        getMob().stopUsingItem();
+    }
+
+    default boolean isUsingItem() {
+        return getMob().isUsingItem();
+    }
+
+    default void heal(float amount) {
+        getMob().heal(amount);
+    }
+
+    default PathNavigation getNavigation() {
+        return getMob().getNavigation();
+    }
+
+    default JumpControl getJumpControl() {
+        return getMob().getJumpControl();
+    }
+
+    /**
+     * Obtain a recruit abstraction for the given mob, wrapping vanilla mobs
+     * in a {@link MobRecruit} adapter.
+     */
+    static IRecruitMob of(Mob mob) {
+        return mob instanceof IRecruitMob r ? r : new MobRecruit(mob);
+    }
+}
+

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -1,7 +1,11 @@
 package com.talhanation.recruits.entities;
 
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -11,9 +15,14 @@ import java.util.UUID;
  * their persistent NBT data. This allows command and GUI logic to treat
  * regular mobs the same as {@link AbstractRecruitEntity} instances.
  */
-public class MobRecruit implements IRecruitEntity {
+public class MobRecruit implements IRecruitMob {
 
     private final Mob mob;
+
+    private final SimpleContainer inventory = new SimpleContainer(15);
+    private int beforeItemSlot = -1;
+    private float hunger = 100F;
+    private float morale = 100F;
 
     public MobRecruit(Mob mob) {
         this.mob = mob;
@@ -22,6 +31,13 @@ public class MobRecruit implements IRecruitEntity {
     private CompoundTag data() {
         return mob.getPersistentData();
     }
+
+    @Override
+    public Mob getMob() {
+        return mob;
+    }
+
+    // basic recruit data ----------------------------------------------------
 
     @Override
     public boolean isOwned() {
@@ -58,8 +74,136 @@ public class MobRecruit implements IRecruitEntity {
         data().putInt("Group", group);
     }
 
-    public Mob getMob() {
-        return mob;
+    // inventory -------------------------------------------------------------
+
+    @Override
+    public SimpleContainer getInventory() {
+        return inventory;
+    }
+
+    @Override
+    public int getInventorySize() {
+        return inventory.getContainerSize();
+    }
+
+    @Override
+    public void setBeforeItemSlot(int slot) {
+        beforeItemSlot = slot;
+    }
+
+    @Override
+    public int getBeforeItemSlot() {
+        return beforeItemSlot;
+    }
+
+    @Override
+    public void resetItemInHand() {
+        ItemStack foodStack = mob.getOffhandItem().copy();
+        ItemStack before = ItemStack.EMPTY;
+        if (beforeItemSlot >= 0 && beforeItemSlot < inventory.getContainerSize()) {
+            before = inventory.getItem(beforeItemSlot).copy();
+            inventory.removeItemNoUpdate(beforeItemSlot);
+        }
+        mob.setItemInHand(InteractionHand.OFF_HAND, before);
+        if (beforeItemSlot >= 0 && beforeItemSlot < inventory.getContainerSize()) {
+            inventory.setItem(beforeItemSlot, foodStack);
+        }
+        beforeItemSlot = -1;
+    }
+
+    @Override
+    public boolean canEatItemStack(ItemStack stack) {
+        return stack.isEdible();
+    }
+
+    // hunger & morale -------------------------------------------------------
+
+    @Override
+    public void updateMorale() {
+    }
+
+    @Override
+    public void updateHunger() {
+    }
+
+    @Override
+    public boolean needsToEat() {
+        return hunger <= 70F;
+    }
+
+    @Override
+    public boolean isSaturated() {
+        return hunger >= 90F;
+    }
+
+    @Override
+    public float getHunger() {
+        return hunger;
+    }
+
+    @Override
+    public void setHunger(float value) {
+        hunger = value;
+    }
+
+    @Override
+    public float getMorale() {
+        return morale;
+    }
+
+    @Override
+    public void setMoral(float value) {
+        morale = value;
+    }
+
+    // state flags -----------------------------------------------------------
+
+    @Override
+    public Vec3 getHoldPos() {
+        return null;
+    }
+
+    @Override
+    public boolean getShouldHoldPos() {
+        return false;
+    }
+
+    @Override
+    public boolean getFleeing() {
+        return false;
+    }
+
+    @Override
+    public boolean needsToGetFood() {
+        return false;
+    }
+
+    @Override
+    public boolean getShouldMount() {
+        return false;
+    }
+
+    @Override
+    public double getMoveSpeed() {
+        return 1.0D;
+    }
+
+    @Override
+    public boolean getRotate() {
+        return false;
+    }
+
+    @Override
+    public void setRotate(boolean rotate) {
+    }
+
+    @Override
+    public float getOwnerRot() {
+        return 0;
+    }
+
+    @Override
+    public void setOwnerRot(float rot) {
     }
 }
 

--- a/src/main/java/com/talhanation/recruits/entities/ai/RecruitEatGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/RecruitEatGoal.java
@@ -1,6 +1,6 @@
 package com.talhanation.recruits.entities.ai;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitMob;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.item.ItemStack;
@@ -8,13 +8,13 @@ import java.util.Objects;
 
 public class RecruitEatGoal extends Goal {
 
-    public AbstractRecruitEntity recruit;
+    public IRecruitMob recruit;
     public ItemStack foodStack;
     public int slotID;
     private long lastCanUseCheckMorale;
     private long lastCanUseCheckHunger;
 
-    public RecruitEatGoal(AbstractRecruitEntity recruit) {
+    public RecruitEatGoal(IRecruitMob recruit) {
         this.recruit = recruit;
     }
 
@@ -71,10 +71,10 @@ public class RecruitEatGoal extends Goal {
         Main.LOGGER.debug("Start--------------:");
         */
 
-        recruit.heal(Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit)).getSaturationModifier() * 1);
+        recruit.heal(Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit.getMob())).getSaturationModifier() * 1);
         if (!recruit.isSaturated()){
-            float saturation = Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit)).getSaturationModifier();
-            float nutrition = Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit)).getNutrition() * 5;
+            float saturation = Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit.getMob())).getSaturationModifier();
+            float nutrition = Objects.requireNonNull(foodStack.getItem().getFoodProperties(foodStack, recruit.getMob())).getNutrition() * 5;
 
             float currentHunger = recruit.getHunger();
             float newHunger = currentHunger + saturation + nutrition;
@@ -105,11 +105,11 @@ public class RecruitEatGoal extends Goal {
     private ItemStack getAndRemoveFoodInInv(){
         ItemStack itemStack = null;
         for(int i = 0; i < recruit.getInventorySize(); i++){
-            ItemStack stackInSlot = recruit.inventory.getItem(i).copy();
+            ItemStack stackInSlot = recruit.getInventory().getItem(i).copy();
             if(recruit.canEatItemStack(stackInSlot)){
                 itemStack = stackInSlot.copy();
                 this.slotID = i;
-                recruit.inventory.removeItemNoUpdate(i); //removing item in slot
+                recruit.getInventory().removeItemNoUpdate(i); //removing item in slot
                 break;
             }
         }

--- a/src/main/java/com/talhanation/recruits/entities/ai/RecruitHoldPosGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/RecruitHoldPosGoal.java
@@ -1,18 +1,17 @@
 package com.talhanation.recruits.entities.ai;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitMob;
 import net.minecraft.world.entity.ai.goal.Goal;
-import net.minecraft.core.BlockPos;
 import net.minecraft.world.phys.Vec3;
 
 import java.util.EnumSet;
 
 public class RecruitHoldPosGoal extends Goal {
-    private final AbstractRecruitEntity recruit;
+    private final IRecruitMob recruit;
 
     private int timeToRecalcPath;
 
-    public RecruitHoldPosGoal(AbstractRecruitEntity recruit, double within) {
+    public RecruitHoldPosGoal(IRecruitMob recruit, double within) {
       this.recruit = recruit;
       this.setFlags(EnumSet.of(Goal.Flag.MOVE));
     }
@@ -38,23 +37,23 @@ public class RecruitHoldPosGoal extends Goal {
     public void tick() {
         Vec3 pos = this.recruit.getHoldPos();
         if (pos != null) {
-            double distance = recruit.distanceToSqr(pos);
+            double distance = recruit.getMob().distanceToSqr(pos);
             if(distance >= 0.3) {
                 if (--this.timeToRecalcPath <= 0) {
-                    this.timeToRecalcPath = this.recruit.getVehicle() != null ? this.adjustedTickDelay(5) : this.adjustedTickDelay(10);
-                    this.recruit.getNavigation().moveTo(pos.x(), pos.y(), pos.z(), this.recruit.moveSpeed);
+                    this.timeToRecalcPath = this.recruit.getMob().getVehicle() != null ? this.adjustedTickDelay(5) : this.adjustedTickDelay(10);
+                    this.recruit.getNavigation().moveTo(pos.x(), pos.y(), pos.z(), this.recruit.getMoveSpeed());
                 }
 
-                if (recruit.horizontalCollision || recruit.minorHorizontalCollision) {
+                if (recruit.getMob().horizontalCollision || recruit.getMob().minorHorizontalCollision) {
                     this.recruit.getJumpControl().jump();
                 }
             } else{
-                if(recruit.rotate){
-                    this.recruit.setYRot(recruit.ownerRot);
-                    this.recruit.yRotO = this.recruit.ownerRot;
-                    this.recruit.yBodyRot = this.recruit.ownerRot;
-                    this.recruit.yHeadRot = this.recruit.ownerRot;
-                    recruit.rotate = false;
+                if(recruit.getRotate()){
+                    recruit.getMob().setYRot(recruit.getOwnerRot());
+                    recruit.getMob().yRotO = recruit.getOwnerRot();
+                    recruit.getMob().yBodyRot = recruit.getOwnerRot();
+                    recruit.getMob().yHeadRot = recruit.getOwnerRot();
+                    recruit.setRotate(false);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add `IRecruitMob` interface that exposes inventory, hunger and recruit state to AI goals
- wrap vanilla mobs in `MobRecruit` implementing the new interface
- update recruit eating and hold-position goals to use the generalized interface

## Testing
- `./gradlew test` *(fails: NoClassDefFoundError in tests)*
- `./gradlew build` *(fails: There were failing tests)*
- `./gradlew check` *(fails: There were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e3e2abc688327b8c3ec8b72f0d5b3