### PR TITLE
Add recruit wrappers for vanilla mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/CompanionMobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/CompanionMobRecruit.java
@@ -1,0 +1,49 @@
+package com.talhanation.recruits.entities;
+
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Delegate wrapper for companion-style behaviour on vanilla mobs. Stores
+ * companion specific data in persistent NBT so they can participate in
+ * recruit systems without extending {@link AbstractRecruitEntity}.
+ */
+public class CompanionMobRecruit extends MobRecruit implements ICompanion {
+
+    private static final String KEY_OWNER_NAME = "OwnerName";
+    private static final String KEY_AT_MISSION = "AtMission";
+
+    public CompanionMobRecruit(Mob mob) {
+        super(mob);
+    }
+
+    @Override
+    public AbstractRecruitEntity get() {
+        throw new UnsupportedOperationException("Vanilla mob has no recruit entity");
+    }
+
+    @Override
+    public void openSpecialGUI(Player player) {
+        // Vanilla mobs do not expose a companion GUI.
+    }
+
+    @Override
+    public String getOwnerName() {
+        return getString(KEY_OWNER_NAME);
+    }
+
+    @Override
+    public void setOwnerName(String name) {
+        setString(KEY_OWNER_NAME, name);
+    }
+
+    @Override
+    public boolean isAtMission() {
+        return getBoolean(KEY_AT_MISSION);
+    }
+
+    public void setAtMission(boolean atMission) {
+        setBoolean(KEY_AT_MISSION, atMission);
+    }
+}
+

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -1,7 +1,10 @@
 package com.talhanation.recruits.entities;
 
-import net.minecraft.world.entity.Mob;
+import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.Container;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.npc.InventoryCarrier;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -13,49 +16,148 @@ import java.util.UUID;
  */
 public class MobRecruit implements IRecruitEntity {
 
+    private static final String KEY_OWNED = "Owned";
+    private static final String KEY_OWNER = "Owner";
+    private static final String KEY_GROUP = "Group";
+    private static final String KEY_FOLLOW_STATE = "FollowState";
+    private static final String KEY_SHOULD_FOLLOW = "ShouldFollow";
+    private static final String KEY_PAYMENT_TIMER = "paymentTimer";
+    private static final String KEY_UPKEEP_TIMER = "upkeepTimer";
+    private static final String KEY_MOUNT_TIMER = "mountTimer";
+
     private final Mob mob;
 
     public MobRecruit(Mob mob) {
         this.mob = mob;
     }
 
-    private CompoundTag data() {
+    protected CompoundTag data() {
         return mob.getPersistentData();
+    }
+
+    protected boolean getBoolean(String key) {
+        return data().getBoolean(key);
+    }
+
+    protected void setBoolean(String key, boolean value) {
+        data().putBoolean(key, value);
+    }
+
+    protected int getInt(String key) {
+        return data().getInt(key);
+    }
+
+    protected void setInt(String key, int value) {
+        data().putInt(key, value);
+    }
+
+    protected long getLong(String key) {
+        return data().getLong(key);
+    }
+
+    protected void setLong(String key, long value) {
+        data().putLong(key, value);
+    }
+
+    protected String getString(String key) {
+        return data().getString(key);
+    }
+
+    protected void setString(String key, String value) {
+        data().putString(key, value);
+    }
+
+    @Nullable
+    protected BlockPos getBlockPos(String key) {
+        return data().contains(key) ? BlockPos.of(data().getLong(key)) : null;
+    }
+
+    protected void setBlockPos(String key, @Nullable BlockPos pos) {
+        if (pos == null) {
+            data().remove(key);
+        } else {
+            setLong(key, pos.asLong());
+        }
     }
 
     @Override
     public boolean isOwned() {
-        return data().getBoolean("Owned");
+        return getBoolean(KEY_OWNED);
     }
 
     @Override
     public void setIsOwned(boolean owned) {
-        data().putBoolean("Owned", owned);
+        setBoolean(KEY_OWNED, owned);
     }
 
     @Nullable
     @Override
     public UUID getOwnerUUID() {
-        return data().hasUUID("Owner") ? data().getUUID("Owner") : null;
+        return data().hasUUID(KEY_OWNER) ? data().getUUID(KEY_OWNER) : null;
     }
 
     @Override
     public void setOwnerUUID(@Nullable UUID uuid) {
         if (uuid == null) {
-            data().remove("Owner");
+            data().remove(KEY_OWNER);
         } else {
-            data().putUUID("Owner", uuid);
+            data().putUUID(KEY_OWNER, uuid);
         }
     }
 
     @Override
     public int getGroup() {
-        return data().getInt("Group");
+        return getInt(KEY_GROUP);
     }
 
     @Override
     public void setGroup(int group) {
-        data().putInt("Group", group);
+        setInt(KEY_GROUP, group);
+    }
+
+    public int getFollowState() {
+        return getInt(KEY_FOLLOW_STATE);
+    }
+
+    public void setFollowState(int state) {
+        setInt(KEY_FOLLOW_STATE, state);
+    }
+
+    public boolean getShouldFollow() {
+        return getBoolean(KEY_SHOULD_FOLLOW);
+    }
+
+    public void setShouldFollow(boolean shouldFollow) {
+        setBoolean(KEY_SHOULD_FOLLOW, shouldFollow);
+    }
+
+    public int getPaymentTimer() {
+        return getInt(KEY_PAYMENT_TIMER);
+    }
+
+    public void setPaymentTimer(int timer) {
+        setInt(KEY_PAYMENT_TIMER, timer);
+    }
+
+    public int getUpkeepTimer() {
+        return getInt(KEY_UPKEEP_TIMER);
+    }
+
+    public void setUpkeepTimer(int timer) {
+        setInt(KEY_UPKEEP_TIMER, timer);
+    }
+
+    public int getMountTimer() {
+        return getInt(KEY_MOUNT_TIMER);
+    }
+
+    public void setMountTimer(int timer) {
+        setInt(KEY_MOUNT_TIMER, timer);
+    }
+
+    @Nullable
+    public Container getInventory() {
+        return mob instanceof InventoryCarrier carrier ? carrier.getInventory() : null;
     }
 
     public Mob getMob() {

--- a/src/main/java/com/talhanation/recruits/entities/RangedMobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/RangedMobRecruit.java
@@ -1,0 +1,50 @@
+package com.talhanation.recruits.entities;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.monster.RangedAttackMob;
+
+import javax.annotation.Nullable;
+
+/**
+ * Delegate for ranged vanilla mobs. Implements recruit ranged
+ * interfaces so command logic can interact with skeletons or other
+ * shooters using the same code paths as real recruits.
+ */
+public class RangedMobRecruit extends MobRecruit implements IRangedRecruit, IStrategicFire {
+
+    private static final String KEY_STRATEGIC_FIRE = "ShouldStrategicFire";
+    private static final String KEY_STRATEGIC_FIRE_POS = "StrategicFirePos";
+
+    public RangedMobRecruit(Mob mob) {
+        super(mob);
+    }
+
+    @Override
+    public void performRangedAttack(LivingEntity target, float distanceFactor) {
+        if (getMob() instanceof RangedAttackMob ranged) {
+            ranged.performRangedAttack(target, distanceFactor);
+        }
+    }
+
+    @Override
+    public void setShouldStrategicFire(boolean should) {
+        setBoolean(KEY_STRATEGIC_FIRE, should);
+    }
+
+    @Override
+    public void setStrategicFirePos(BlockPos blockpos) {
+        setBlockPos(KEY_STRATEGIC_FIRE_POS, blockpos);
+    }
+
+    public boolean shouldStrategicFire() {
+        return getBoolean(KEY_STRATEGIC_FIRE);
+    }
+
+    @Nullable
+    public BlockPos getStrategicFirePos() {
+        return getBlockPos(KEY_STRATEGIC_FIRE_POS);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expand MobRecruit NBT handling with follow state, timers and inventory access
- add RangedMobRecruit and CompanionMobRecruit delegates implementing recruit interfaces

## Testing
- `./gradlew build` *(fails: 7 tests)*
- `./gradlew test` *(fails: 7 tests)*
- `./gradlew check` *(fails: 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_688e3e2b92208327b629b4e00050ef46