### PR TITLE
Rename carrier inventory accessor

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -171,8 +171,15 @@ public class MobRecruit implements IRecruitMob {
         setInt(KEY_MOUNT_TIMER, timer);
     }
 
+    /**
+     * Access the vanilla inventory of the wrapped mob when it implements
+     * {@link InventoryCarrier}. This is separate from the recruit-specific
+     * {@link #getInventory()} container used by the wrapper.
+     *
+     * @return the mob's own inventory or {@code null} if it has none
+     */
     @Nullable
-    public Container getInventory() {
+    public Container getCarrierInventory() {
         return mob instanceof InventoryCarrier carrier ? carrier.getInventory() : null;
     }
 


### PR DESCRIPTION
## Summary
- rename `MobRecruit`'s vanilla inventory getter to `getCarrierInventory` and document its role

## Testing
- `./gradlew build` *(fails: 7 tests failed)*
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew check` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688e4568deb48327ae72fb89c13666c9