### PR TITLE
Use persistent NBT for generic mob recruits

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -1,11 +1,15 @@
 package com.talhanation.recruits.entities;
 
+import com.talhanation.recruits.config.RecruitsServerConfig;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.Container;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.npc.InventoryCarrier;
-
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -26,27 +30,31 @@ public class MobRecruit implements IRecruitMob {
     private static final String KEY_UPKEEP_TIMER = "upkeepTimer";
     private static final String KEY_MOUNT_TIMER = "mountTimer";
 
-    private static final String KEY_OWNED = "Owned";
-    private static final String KEY_OWNER = "Owner";
-    private static final String KEY_GROUP = "Group";
-    private static final String KEY_FOLLOW_STATE = "FollowState";
-    private static final String KEY_SHOULD_FOLLOW = "ShouldFollow";
-    private static final String KEY_PAYMENT_TIMER = "paymentTimer";
-    private static final String KEY_UPKEEP_TIMER = "upkeepTimer";
-    private static final String KEY_MOUNT_TIMER = "mountTimer";
+    private static final String KEY_HOLD_X = "HoldX";
+    private static final String KEY_HOLD_Y = "HoldY";
+    private static final String KEY_HOLD_Z = "HoldZ";
+    private static final String KEY_SHOULD_HOLD_POS = "ShouldHoldPos";
+    private static final String KEY_FLEEING = "Fleeing";
+    private static final String KEY_SHOULD_MOUNT = "ShouldMount";
+    private static final String KEY_ROTATE = "Rotate";
+    private static final String KEY_OWNER_ROT = "OwnerRot";
+    private static final String KEY_HUNGER = "Hunger";
+    private static final String KEY_MORAL = "Moral";
+    private static final String KEY_MOVE_SPEED = "MoveSpeed";
+    private static final String KEY_UPKEEP_UUID = "UpkeepUUID";
+    private static final String KEY_UPKEEP_POS_X = "UpkeepPosX";
+    private static final String KEY_UPKEEP_POS_Y = "UpkeepPosY";
+    private static final String KEY_UPKEEP_POS_Z = "UpkeepPosZ";
 
     private final Mob mob;
-
     private final SimpleContainer inventory = new SimpleContainer(15);
     private int beforeItemSlot = -1;
-    private float hunger = 100F;
-    private float morale = 100F;
 
     public MobRecruit(Mob mob) {
         this.mob = mob;
     }
 
-    protected CompoundTag data() {
+    private CompoundTag data() {
         return mob.getPersistentData();
     }
 
@@ -66,12 +74,20 @@ public class MobRecruit implements IRecruitMob {
         data().putInt(key, value);
     }
 
-    protected long getLong(String key) {
-        return data().getLong(key);
+    protected float getFloat(String key) {
+        return data().getFloat(key);
     }
 
-    protected void setLong(String key, long value) {
-        data().putLong(key, value);
+    protected void setFloat(String key, float value) {
+        data().putFloat(key, value);
+    }
+
+    protected double getDouble(String key) {
+        return data().getDouble(key);
+    }
+
+    protected void setDouble(String key, double value) {
+        data().putDouble(key, value);
     }
 
     protected String getString(String key) {
@@ -91,7 +107,7 @@ public class MobRecruit implements IRecruitMob {
         if (pos == null) {
             data().remove(key);
         } else {
-            setLong(key, pos.asLong());
+            data().putLong(key, pos.asLong());
         }
     }
 
@@ -100,8 +116,10 @@ public class MobRecruit implements IRecruitMob {
         return mob;
     }
 
-    // basic recruit data ----------------------------------------------------
-  
+    // ---------------------------------------------------------------------
+    // Basic recruit data
+    // ---------------------------------------------------------------------
+
     @Override
     public boolean isOwned() {
         return getBoolean(KEY_OWNED);
@@ -178,63 +196,13 @@ public class MobRecruit implements IRecruitMob {
     }
 
     @Nullable
-    public Container getInventory() {
-        return mob instanceof InventoryCarrier carrier ? carrier.getInventory() : null;
-    }
-
-    public int getFollowState() {
-        return getInt(KEY_FOLLOW_STATE);
-    }
-
-    public void setFollowState(int state) {
-        setInt(KEY_FOLLOW_STATE, state);
-    }
-
-    public boolean getShouldFollow() {
-        return getBoolean(KEY_SHOULD_FOLLOW);
-    }
-
-    public void setShouldFollow(boolean shouldFollow) {
-        setBoolean(KEY_SHOULD_FOLLOW, shouldFollow);
-    }
-
-    public int getPaymentTimer() {
-        return getInt(KEY_PAYMENT_TIMER);
-    }
-
-    public void setPaymentTimer(int timer) {
-        setInt(KEY_PAYMENT_TIMER, timer);
-    }
-
-    public int getUpkeepTimer() {
-        return getInt(KEY_UPKEEP_TIMER);
-    }
-
-    public void setUpkeepTimer(int timer) {
-        setInt(KEY_UPKEEP_TIMER, timer);
-    }
-
-    public int getMountTimer() {
-        return getInt(KEY_MOUNT_TIMER);
-    }
-
-    public void setMountTimer(int timer) {
-        setInt(KEY_MOUNT_TIMER, timer);
-    }
-
-    /**
-     * Access the vanilla inventory of the wrapped mob when it implements
-     * {@link InventoryCarrier}. This is separate from the recruit-specific
-     * {@link #getInventory()} container used by the wrapper.
-     *
-     * @return the mob's own inventory or {@code null} if it has none
-     */
-    @Nullable
     public Container getCarrierInventory() {
         return mob instanceof InventoryCarrier carrier ? carrier.getInventory() : null;
     }
 
-    // inventory -------------------------------------------------------------
+    // ---------------------------------------------------------------------
+    // Inventory
+    // ---------------------------------------------------------------------
 
     @Override
     public SimpleContainer getInventory() {
@@ -276,94 +244,164 @@ public class MobRecruit implements IRecruitMob {
         return stack.isEdible();
     }
 
-    // hunger & morale -------------------------------------------------------
+    private boolean hasFoodInInv() {
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            if (canEatItemStack(inventory.getItem(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // ---------------------------------------------------------------------
+    // Hunger & morale
+    // ---------------------------------------------------------------------
 
     @Override
     public void updateMorale() {
+        float current = getMorale();
+        float morale = current;
+
+        if (isStarving() && isOwned()) {
+            if (current > 0) morale -= 2F;
+        }
+
+        if (isOwned() && !isSaturated()) {
+            if (current > 35) morale -= 1F;
+        }
+
+        if (isSaturated() || mob.getHealth() >= mob.getMaxHealth() * 0.85F) {
+            if (current < 65) morale += 2F;
+        }
+
+        if (morale < 0) morale = 0;
+        setMoral(morale);
     }
 
     @Override
     public void updateHunger() {
+        if (!RecruitsServerConfig.RecruitHunger.get())
+            return;
+        float hunger = getHunger();
+        if (getFollowState() == 2) {
+            hunger -= 2F / 60F;
+        } else {
+            hunger -= 3F / 60F;
+        }
+        if (hunger < 0) hunger = 0;
+        setHunger(hunger);
     }
 
     @Override
     public boolean needsToEat() {
-        return hunger <= 70F;
+        if (!RecruitsServerConfig.RecruitHunger.get())
+            return false;
+        if (getHunger() <= 50F) {
+            return true;
+        }
+        if (getHunger() <= 70F && mob.getHealth() != mob.getMaxHealth() && mob.getTarget() == null && isOwned()) {
+            return true;
+        }
+        return mob.getHealth() <= mob.getMaxHealth() * 0.30F && mob.getTarget() == null;
     }
 
     @Override
     public boolean isSaturated() {
-        return hunger >= 90F;
+        if (!RecruitsServerConfig.RecruitHunger.get())
+            return true;
+        return getHunger() >= 90F;
+    }
+
+    private boolean isStarving() {
+        if (!RecruitsServerConfig.RecruitHunger.get())
+            return false;
+        return getHunger() <= 1F;
     }
 
     @Override
     public float getHunger() {
-        return hunger;
+        return data().contains(KEY_HUNGER) ? getFloat(KEY_HUNGER) : 100F;
     }
 
     @Override
     public void setHunger(float value) {
-        hunger = value;
+        setFloat(KEY_HUNGER, value);
     }
 
     @Override
     public float getMorale() {
-        return morale;
+        return data().contains(KEY_MORAL) ? getFloat(KEY_MORAL) : 100F;
     }
 
     @Override
     public void setMoral(float value) {
-        morale = value;
+        setFloat(KEY_MORAL, value);
     }
 
-    // state flags -----------------------------------------------------------
+    // ---------------------------------------------------------------------
+    // State flags
+    // ---------------------------------------------------------------------
 
     @Override
     public Vec3 getHoldPos() {
+        if (data().contains(KEY_HOLD_X) && data().contains(KEY_HOLD_Y) && data().contains(KEY_HOLD_Z)) {
+            return new Vec3(
+                    getDouble(KEY_HOLD_X),
+                    getDouble(KEY_HOLD_Y),
+                    getDouble(KEY_HOLD_Z)
+            );
+        }
         return null;
     }
 
     @Override
     public boolean getShouldHoldPos() {
-        return false;
+        return getBoolean(KEY_SHOULD_HOLD_POS);
     }
 
     @Override
     public boolean getFleeing() {
-        return false;
+        return getBoolean(KEY_FLEEING);
     }
 
     @Override
     public boolean needsToGetFood() {
-        return false;
+        int timer = getUpkeepTimer();
+        boolean needsToEat = needsToEat();
+        boolean hasFood = hasFoodInInv();
+        boolean isChest = data().contains(KEY_UPKEEP_POS_X) && data().contains(KEY_UPKEEP_POS_Y) && data().contains(KEY_UPKEEP_POS_Z);
+        boolean isEntity = data().hasUUID(KEY_UPKEEP_UUID);
+        return (!hasFood && timer == 0 && needsToEat) && (isChest || isEntity);
     }
 
     @Override
     public boolean getShouldMount() {
-        return false;
+        return getBoolean(KEY_SHOULD_MOUNT);
     }
 
     @Override
     public double getMoveSpeed() {
-        return 1.0D;
+        return data().contains(KEY_MOVE_SPEED) ? getDouble(KEY_MOVE_SPEED) : 1.0D;
     }
 
     @Override
     public boolean getRotate() {
-        return false;
+        return getBoolean(KEY_ROTATE);
     }
 
     @Override
     public void setRotate(boolean rotate) {
+        setBoolean(KEY_ROTATE, rotate);
     }
 
     @Override
     public float getOwnerRot() {
-        return 0;
+        return data().contains(KEY_OWNER_ROT) ? getFloat(KEY_OWNER_ROT) : 0F;
     }
 
     @Override
     public void setOwnerRot(float rot) {
+        setFloat(KEY_OWNER_ROT, rot);
     }
 }
 


### PR DESCRIPTION
## Summary
- Back generic mob recruit state like hunger, morale, hold positions, fleeing, and rotation with persistent NBT fields
- Mirror AbstractRecruitEntity logic so wrapped mobs update hunger/morale and honor formation and rotation commands

## Testing
- `./gradlew test` *(fails: RecruitBehaviorTest issues)*
- `./gradlew check` *(fails: RecruitBehaviorTest issues)*
- `./gradlew build` *(fails: RecruitBehaviorTest issues)*

------
https://chatgpt.com/codex/tasks/task_e_688e4d0d6ab48327880a8058bd9dfe22