### PR TITLE
Document controlled mob requirements and warn on unsupported mobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ which food items recruits are willing to eat.
 
 ### Controlled mobs
 
-Right-click an owned controlled mob to open its inventory and command screen.
+Only mobs flagged with `RecruitControlled` will obey recruit commands. This can
+be enabled globally via the `UniversalMobControl` config or for specific mobs by
+adding their ids to `ControlledMobIds`. Right-click an owned controlled mob to
+open its inventory and command screen.
 
 https://www.curseforge.com/minecraft/mc-mods/recruits
 

--- a/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
+++ b/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
@@ -21,14 +21,17 @@ public class MobRecruitHandler implements RecruitHandler {
     @Override
     public void handle(PlayerInteractEvent event, Mob mob) {
         CompoundTag nbt = mob.getPersistentData();
+        Player player = event.getEntity();
         if (nbt.getBoolean("RecruitControlled")) {
             RecruitEventsAccessor.restoreControlledMobInventory(mob);
         } else if (TeamEvents.isControlledMob(mob.getType())) {
             RecruitEventsAccessor.initializeControlledMob(mob);
+        } else {
+            player.sendSystemMessage(Component.literal(
+                    "This mob cannot be recruited. Add its id to ControlledMobIds or enable UniversalMobControl."));
         }
         if (!nbt.getBoolean("RecruitControlled")) return;
 
-        Player player = event.getEntity();
         ItemStack currency = TeamEvents.getCurrencyForMob(mob.getType());
 
         if (!nbt.getBoolean("Owned")) {


### PR DESCRIPTION
## Summary
- document that only mobs with `RecruitControlled` will respond to commands
- warn players when trying to recruit mobs not allowed by config

## Testing
- `./gradlew build` *(fails: variable KEY_OWNED is already defined in class MobRecruit)*
- `./gradlew test` *(fails: variable KEY_OWNED is already defined in class MobRecruit)*
- `./gradlew check` *(fails: variable KEY_OWNED is already defined in class MobRecruit)*

------
https://chatgpt.com/codex/tasks/task_e_688e4d0e516c8327a5e305c10454a4d5