### PR TITLE
Fix mob recruit GUI lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ be enabled globally via the `UniversalMobControl` config or for specific mobs by
 adding their ids to `ControlledMobIds`. Right-click an owned controlled mob to
 open its inventory and command screen.
 
+If the GUI fails to open for a converted mob, update to a version where the
+client no longer depends on the unsynchronized `RecruitControlled` flag. See
+[docs/mob-recruit-gui.md](docs/mob-recruit-gui.md) for details.
+
 https://www.curseforge.com/minecraft/mc-mods/recruits
 
 All Rights Reserved unless otherwise explicitly stated.

--- a/docs/mob-recruit-gui.md
+++ b/docs/mob-recruit-gui.md
@@ -1,0 +1,10 @@
+# Mob recruit GUI issue
+
+## Summary
+The recruit inventory GUI failed to open for mobs converted with UniversalMobControl. The client attempted to locate the mob using `ModScreens.getControlledMobByUUID`, which required the mob's `RecruitControlled` NBT flag to be present. This flag is written only on the server, so the client could not find the mob and the screen creation returned `null`.
+
+## Resolution
+`ModScreens.getControlledMobByUUID` now matches mobs purely by UUID and no longer checks the unsynchronized `RecruitControlled` flag. The server still validates that a mob is controlled before opening its inventory, allowing the GUI to load correctly.
+
+## Preventing similar bugs
+When adding data that must be read on both client and server, use `SynchedEntityData` or send a dedicated network packet so the information is synchronized. Avoid relying on persistent NBT values for client-side logic unless those values are explicitly mirrored to the client.

--- a/src/main/java/com/talhanation/recruits/init/ModScreens.java
+++ b/src/main/java/com/talhanation/recruits/init/ModScreens.java
@@ -301,7 +301,9 @@ public class ModScreens {
                             player.getY() + distance,
                             player.getZ() + distance),
                     entity -> !(entity instanceof AbstractRecruitEntity) &&
-                            entity.getPersistentData().getBoolean("RecruitControlled") &&
+                            // The "RecruitControlled" flag is stored only on the server.
+                            // Rely on the server to validate controlled mobs and avoid
+                            // client-side checks that depend on unsynchronized NBT data.
                             entity.getUUID().equals(uuid)
             ).stream().findAny().orElse(null);
     }


### PR DESCRIPTION
## Summary
- allow clients to locate controlled mobs by UUID without relying on server-only NBT
- document mob recruit GUI problem and preventive tips
- note troubleshooting guidance in README

## Testing
- `./gradlew build` *(fails: 7 tests failed)*
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew check` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894bd7216f48327bb9b12937e5b6696