### PR TITLE
Cycle recruit follow states

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -1153,6 +1153,7 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
                     int state = this.getFollowState();
                     switch (state) {
                         default -> {
+                            this.clearHoldPos();
                             setFollowState(1);
                             player.sendSystemMessage(TEXT_FOLLOW(name));
                         }
@@ -1160,8 +1161,9 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
                             setFollowState(4);
                             player.sendSystemMessage(TEXT_HOLD_YOUR_POS(name));
                         }
-                        case 3 -> {
+                        case 4, 3 -> {
                             setFollowState(0);
+                            this.clearHoldPos();
                             player.sendSystemMessage(TEXT_WANDER(name));
                         }
                     }


### PR DESCRIPTION
## Summary
- Cycle recruit follow state right-click interaction so it steps follow → hold → wander, matching mob recruit handler logic
- Clear hold position when switching between follow and wander states for consistency

## Testing
- `./gradlew test` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8f2a64083278d378a3243cf9316