### PR TITLE
Ensure recruits listen by default

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -1007,6 +1007,7 @@ public class RecruitEvents {
         recruit.setOwnerUUID(null);
         nbt.putInt("FollowState", 0);
         nbt.putInt("AggroState", 0); // neutral by default; mobs engage only enemies or threats
+        nbt.putBoolean("Listen", true);
         nbt.putInt("PaymentTimer", AbstractRecruitEntity.getPaymentIntervalTicks());
       
         // initialize fields also used by recruits so that newly controlled mobs

--- a/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/AbstractRecruitEntity.java
@@ -1199,6 +1199,7 @@ public abstract class AbstractRecruitEntity extends AbstractInventoryEntity impl
             this.resetPaymentTimer();
             this.setOwnerUUID(Optional.of(player.getUUID()));
             this.setIsOwned(true);
+            this.setListen(true);
             this.navigation.stop();
             this.setTarget(null);
             this.setFollowState(2);

--- a/src/main/java/com/talhanation/recruits/items/RecruitsSpawnEgg.java
+++ b/src/main/java/com/talhanation/recruits/items/RecruitsSpawnEgg.java
@@ -101,7 +101,7 @@ public class RecruitsSpawnEgg extends ForgeSpawnEggItem {
         recruit.setShouldProtect(nbt.getBoolean("ShouldProtect"));
         recruit.setFleeing(nbt.getBoolean("Fleeing"));
         recruit.setGroup(nbt.getInt("Group"));
-        recruit.setListen(nbt.getBoolean("Listen"));
+        recruit.setListen(nbt.contains("Listen") ? nbt.getBoolean("Listen") : true);
         recruit.setIsFollowing(nbt.getBoolean("isFollowing"));
         recruit.setXp(nbt.getInt("Xp"));
         recruit.setKills(nbt.getInt("Kills"));

--- a/src/main/java/com/talhanation/recruits/network/MessageListen.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageListen.java
@@ -3,6 +3,7 @@ package com.talhanation.recruits.network;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
@@ -33,7 +34,12 @@ public class MessageListen implements Message<MessageListen> {
                 AbstractRecruitEntity.class,
                 player.getBoundingBox().inflate(100),
                 (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> recruit.setListen(bool));
+        ).forEach((recruit) -> {
+            recruit.setListen(bool);
+            player.sendSystemMessage(Component.translatable(
+                    bool ? "chat.recruits.text.listen_on" : "chat.recruits.text.listen_off",
+                    recruit.getName()));
+        });
     }
 
     public MessageListen fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
+++ b/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
@@ -41,6 +41,7 @@ public class MobRecruitHandler implements RecruitHandler {
                 nbt.putBoolean("Owned", true);
                 nbt.putUUID("Owner", player.getUUID());
                 nbt.putInt("FollowState", 1);
+                nbt.putBoolean("Listen", true);
                 RecruitEventsAccessor.resetControlledMobPaymentTimer(mob);
                 if (mob instanceof PathfinderMob pathfinderMob) {
                     RecruitEventsAccessor.applyControlledMobGoals(pathfinderMob);

--- a/src/main/resources/assets/recruits/lang/en_us.json
+++ b/src/main/resources/assets/recruits/lang/en_us.json
@@ -203,6 +203,8 @@
   "chat.recruits.text.recruited1": "%s: That's an honorable path you're on.",
   "chat.recruits.text.recruited2": "%s: How can i assist you?",
   "chat.recruits.text.recruited3": "%s: Your way is my way. Im honored.",
+  "chat.recruits.text.listen_on": "%s: I'm listening.",
+  "chat.recruits.text.listen_off": "%s: I'm ignoring your commands.",
   "chat.recruits.text.protect_died": "%s: The Mob under protection has been killed.",
   "chat.recruits.text.noMount": "%s: There is no mob or vehicle around me!",
   "chat.recruits.text.noPaymentInUpkeep": "%s: There is no payment in my upkeep or my inventory.",


### PR DESCRIPTION
## Summary
- keep listening toggle in command check and default it to true
- ensure hire, spawn eggs, and controlled mob conversion all enable listening
- show chat feedback when toggling listening state

## Testing
- `./gradlew build` *(fails: 7 tests)*
- `./gradlew test` *(fails: 7 tests)*
- `./gradlew check` *(fails: 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6894c8f36e4c83278262b0a8bf2eedb0