### PR TITLE
Add Aggro state control for recruited mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -60,7 +60,7 @@ import com.talhanation.recruits.entities.ai.compat.ControlledMobRestGoal;
 import com.talhanation.recruits.util.MobRecruitHandler;
 import com.talhanation.recruits.util.RecruitHandler;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
-import net.minecraft.world.entity.ai.goal.target.NearestAttackableTargetGoal;
+import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.entity.monster.RangedAttackMob;
 import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
@@ -1036,12 +1036,52 @@ public class RecruitEvents {
         pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
         pathfinderMob.goalSelector.addGoal(5, new ControlledMobRestGoal(pathfinderMob));
         if (pathfinderMob instanceof RangedAttackMob ranged) {
-            pathfinderMob.goalSelector.addGoal(4, new ControlledMobRangedBowAttackGoal<>((PathfinderMob & RangedAttackMob) ranged, 1.0D, 20, 15.0F));
+            Goal attack = new ControlledMobRangedBowAttackGoal<>((PathfinderMob & RangedAttackMob) ranged, 1.0D, 20, 15.0F);
+            pathfinderMob.goalSelector.addGoal(4, wrapAggroCheck(pathfinderMob, attack));
         } else {
-            pathfinderMob.goalSelector.addGoal(4, new ControlledMobMeleeAttackGoal(pathfinderMob, 1.2D, true));
+            Goal attack = new ControlledMobMeleeAttackGoal(pathfinderMob, 1.2D, true);
+            pathfinderMob.goalSelector.addGoal(4, wrapAggroCheck(pathfinderMob, attack));
         }
         pathfinderMob.targetSelector.addGoal(1, new HurtByTargetGoal(pathfinderMob));
-        pathfinderMob.targetSelector.addGoal(2, new ControlledMobTargetGoal(pathfinderMob));
+        pathfinderMob.targetSelector.addGoal(2, wrapAggroCheck(pathfinderMob, new ControlledMobTargetGoal(pathfinderMob)));
+    }
+
+    private static Goal wrapAggroCheck(PathfinderMob mob, Goal goal) {
+        return new Goal() {
+            {
+                this.setFlags(goal.getFlags());
+            }
+
+            @Override
+            public boolean canUse() {
+                return mob.getPersistentData().getInt("AggroState") != 3 && goal.canUse();
+            }
+
+            @Override
+            public boolean canContinueToUse() {
+                return mob.getPersistentData().getInt("AggroState") != 3 && goal.canContinueToUse();
+            }
+
+            @Override
+            public void start() {
+                goal.start();
+            }
+
+            @Override
+            public void stop() {
+                goal.stop();
+            }
+
+            @Override
+            public void tick() {
+                goal.tick();
+            }
+
+            @Override
+            public boolean requiresUpdateEveryTick() {
+                return goal.requiresUpdateEveryTick();
+            }
+        };
     }
 
     private static void maybeReplaceRecruit(AbstractRecruitEntity recruit){

--- a/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
@@ -6,6 +6,7 @@ import com.talhanation.recruits.Main;
 import com.talhanation.recruits.RecruitEvents;
 import com.talhanation.recruits.inventory.ControlledMobMenu;
 import com.talhanation.recruits.network.MessageControlledMobGroup;
+import com.talhanation.recruits.network.MessageAggroGui;
 import com.talhanation.recruits.network.MessageRenameMob;
 import com.talhanation.recruits.entities.IRecruitEntity;
 import net.minecraft.client.gui.GuiGraphics;
@@ -37,11 +38,21 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
     public static float morale;
     public static float hunger;
 
+    private static final MutableComponent TEXT_PASSIVE = Component.translatable("gui.recruits.inv.text.passive");
+    private static final MutableComponent TEXT_NEUTRAL = Component.translatable("gui.recruits.inv.text.neutral");
+    private static final MutableComponent TEXT_AGGRESSIVE = Component.translatable("gui.recruits.inv.text.aggressive");
+    private static final MutableComponent TEXT_RAID = Component.translatable("gui.recruits.inv.text.raid");
+    private static final MutableComponent TOOLTIP_PASSIVE = Component.translatable("gui.recruits.inv.tooltip.passive");
+    private static final MutableComponent TOOLTIP_NEUTRAL = Component.translatable("gui.recruits.inv.tooltip.neutral");
+    private static final MutableComponent TOOLTIP_AGGRESSIVE = Component.translatable("gui.recruits.inv.tooltip.aggressive");
+    private static final MutableComponent TOOLTIP_RAID = Component.translatable("gui.recruits.inv.tooltip.raid");
+
     private static final MutableComponent TEXT_PROMOTE = Component.translatable("gui.recruits.inv.text.promote");
     private static final MutableComponent TOOLTIP_PROMOTE = Component.translatable("gui.recruits.inv.tooltip.promote");
 
     private final Mob mob;
     private EditBox nameField;
+    private int aggro;
 
     public MobRecruitScreen(ControlledMobMenu container, Inventory playerInventory, Component title) {
         super(RESOURCE_LOCATION, container, playerInventory, Component.literal(""), IRecruitEntity.of(container.getMob()));
@@ -67,12 +78,58 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
                 TEXT_PROMOTE,
                 btn -> RecruitEvents.openControlledMobPromoteScreen(minecraft.player, mob)));
         promoteButton.setTooltip(Tooltip.create(TOOLTIP_PROMOTE));
+
+        this.aggro = mob.getPersistentData().getInt("AggroState");
+        int zeroLeftPos = leftPos + 180;
+        int zeroTopPos = topPos + 10;
+        int topPosGap = 5;
+
+        ExtendedButton buttonPassive = new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGap) * 0, 80, 20, TEXT_PASSIVE,
+                btn -> {
+                    this.aggro = mob.getPersistentData().getInt("AggroState");
+                    if (this.aggro != 3) {
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageAggroGui(3, mob.getUUID()));
+                    }
+                });
+        buttonPassive.setTooltip(Tooltip.create(TOOLTIP_PASSIVE));
+        addRenderableWidget(buttonPassive);
+
+        ExtendedButton buttonNeutral = new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGap) * 1, 80, 20, TEXT_NEUTRAL,
+                btn -> {
+                    this.aggro = mob.getPersistentData().getInt("AggroState");
+                    if (this.aggro != 0) {
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageAggroGui(0, mob.getUUID()));
+                    }
+                });
+        buttonNeutral.setTooltip(Tooltip.create(TOOLTIP_NEUTRAL));
+        addRenderableWidget(buttonNeutral);
+
+        ExtendedButton buttonAggressive = new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGap) * 2, 80, 20, TEXT_AGGRESSIVE,
+                btn -> {
+                    this.aggro = mob.getPersistentData().getInt("AggroState");
+                    if (this.aggro != 1) {
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageAggroGui(1, mob.getUUID()));
+                    }
+                });
+        buttonAggressive.setTooltip(Tooltip.create(TOOLTIP_AGGRESSIVE));
+        addRenderableWidget(buttonAggressive);
+
+        ExtendedButton buttonRaid = new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGap) * 3, 80, 20, TEXT_RAID,
+                btn -> {
+                    this.aggro = mob.getPersistentData().getInt("AggroState");
+                    if (this.aggro != 2) {
+                        Main.SIMPLE_CHANNEL.sendToServer(new MessageAggroGui(2, mob.getUUID()));
+                    }
+                });
+        buttonRaid.setTooltip(Tooltip.create(TOOLTIP_RAID));
+        addRenderableWidget(buttonRaid);
     }
 
     @Override
     protected void containerTick() {
         super.containerTick();
         if (nameField != null) nameField.tick();
+        this.aggro = mob.getPersistentData().getInt("AggroState");
     }
 
     @Override
@@ -93,6 +150,16 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
         guiGraphics.drawString(font, String.valueOf((int) morale), k + gap, l + 20, fontColor, false);
         guiGraphics.drawString(font, "Hunger:", k, l + 30, fontColor, false);
         guiGraphics.drawString(font, String.valueOf((int) hunger), k + gap, l + 30, fontColor, false);
+        guiGraphics.drawString(font, "Aggro:", k, l + 40, fontColor, false);
+        String aggroText = switch (this.aggro) {
+            case 0 -> TEXT_NEUTRAL.getString();
+            case 1 -> TEXT_AGGRESSIVE.getString();
+            case 2 -> TEXT_RAID.getString();
+            case 3 -> TEXT_PASSIVE.getString();
+            default -> "?";
+        };
+        int color = this.aggro == 3 ? 16733525 : fontColor;
+        guiGraphics.drawString(font, aggroText, k + gap, l + 40, color, false);
         guiGraphics.pose().popPose();
     }
 

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -26,6 +26,7 @@ public class MobRecruit implements IRecruitMob {
     private static final String KEY_OWNER = "Owner";
     private static final String KEY_GROUP = "Group";
     private static final String KEY_FOLLOW_STATE = "FollowState";
+    private static final String KEY_AGGRO_STATE = "AggroState";
     private static final String KEY_SHOULD_FOLLOW = "ShouldFollow";
     private static final String KEY_PAYMENT_TIMER = "paymentTimer";
     private static final String KEY_UPKEEP_TIMER = "upkeepTimer";
@@ -162,6 +163,14 @@ public class MobRecruit implements IRecruitMob {
 
     public void setFollowState(int state) {
         setInt(KEY_FOLLOW_STATE, state);
+    }
+
+    public int getAggroState() {
+        return data().contains(KEY_AGGRO_STATE) ? getInt(KEY_AGGRO_STATE) : 0;
+    }
+
+    public void setAggroState(int state) {
+        setInt(KEY_AGGRO_STATE, state);
     }
 
     public boolean getShouldFollow() {

--- a/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
@@ -4,6 +4,8 @@ import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -30,10 +32,19 @@ public class MessageAggroGui implements Message<MessageAggroGui> {
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
         player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
+                Mob.class,
                 player.getBoundingBox().inflate(16.0D),
-                (recruit) -> recruit.getUUID().equals(this.uuid)
-        ).forEach((recruit) -> recruit.setState(this.state));
+                m -> m.getUUID().equals(this.uuid) && (m instanceof AbstractRecruitEntity || m.getPersistentData().getBoolean("RecruitControlled"))
+        ).forEach(m -> {
+            if (m instanceof AbstractRecruitEntity recruit) {
+                recruit.setState(this.state);
+            } else {
+                m.getPersistentData().putInt("AggroState", this.state);
+                if (m instanceof PathfinderMob pm && this.state == 3) {
+                    pm.setTarget(null);
+                }
+            }
+        });
     }
 
     public MessageAggroGui fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
+++ b/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
@@ -41,6 +41,7 @@ public class MobRecruitHandler implements RecruitHandler {
                 nbt.putBoolean("Owned", true);
                 nbt.putUUID("Owner", player.getUUID());
                 nbt.putInt("FollowState", 1);
+                nbt.putInt("AggroState", 3); // start passive after recruitment
                 nbt.putBoolean("Listen", true);
                 RecruitEventsAccessor.resetControlledMobPaymentTimer(mob);
                 if (mob instanceof PathfinderMob pathfinderMob) {


### PR DESCRIPTION
## Summary
- store an AggroState flag on MobRecruit and default mobs to passive when hired
- gate controlled mob attack and targeting goals on AggroState
- expose AggroState controls in the mob recruit GUI and sync changes to servers

## Testing
- `./gradlew test` *(fails: CommandEventsTest, RecruitBehaviorTest)*
- `./gradlew check` *(fails: there were failing tests)*
- `./gradlew build` *(fails: there were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68956d1c4a04832786ce06be058b46f6