### PR TITLE
Add musket combat goal for controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -57,6 +57,7 @@ import com.talhanation.recruits.entities.ai.compat.ControlledMobTargetGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobMeleeAttackGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobRangedBowAttackGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobRestGoal;
+import com.talhanation.recruits.entities.ai.compat.ControlledMobRangedMusketAttackGoal;
 import com.talhanation.recruits.util.MobRecruitHandler;
 import com.talhanation.recruits.util.RecruitHandler;
 import net.minecraft.world.entity.ai.goal.target.HurtByTargetGoal;
@@ -1035,13 +1036,26 @@ public class RecruitEvents {
         pathfinderMob.goalSelector.addGoal(7, new ControlledMobFollowOwnerGoal(pathfinderMob, 1.0D, 6.0F, 2.0F));
         pathfinderMob.goalSelector.addGoal(6, new ControlledMobHoldPosGoal(pathfinderMob, 1.0D));
         pathfinderMob.goalSelector.addGoal(5, new ControlledMobRestGoal(pathfinderMob));
-        if (pathfinderMob instanceof RangedAttackMob ranged) {
+        ItemStack mainHand = pathfinderMob.getItemBySlot(EquipmentSlot.MAINHAND);
+        if (isMusket(mainHand)) {
+            pathfinderMob.goalSelector.addGoal(4, new ControlledMobRangedMusketAttackGoal(pathfinderMob, 3.0D));
+        } else if (pathfinderMob instanceof RangedAttackMob ranged) {
             pathfinderMob.goalSelector.addGoal(4, new ControlledMobRangedBowAttackGoal<>((PathfinderMob & RangedAttackMob) ranged, 1.0D, 20, 15.0F));
         } else {
             pathfinderMob.goalSelector.addGoal(4, new ControlledMobMeleeAttackGoal(pathfinderMob, 1.2D, true));
         }
         pathfinderMob.targetSelector.addGoal(1, new HurtByTargetGoal(pathfinderMob));
         pathfinderMob.targetSelector.addGoal(2, new ControlledMobTargetGoal(pathfinderMob));
+    }
+
+    private static boolean isMusket(ItemStack stack) {
+        String id = stack.getDescriptionId();
+        return id.equals("item.musketmod.musket") ||
+                id.equals("item.musketmod.musket_with_bayonet") ||
+                id.equals("item.musketmod.musket_with_scope") ||
+                id.equals("item.musketmod.blunderbuss") ||
+                id.equals("item.musketmod.pistol") ||
+                IWeapon.isCGMWeapon(stack);
     }
 
     private static void maybeReplaceRecruit(AbstractRecruitEntity recruit){

--- a/src/main/java/com/talhanation/recruits/compat/BlunderbussWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/BlunderbussWeapon.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.compat;
 
 import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.Mth;
@@ -232,8 +231,8 @@ public class BlunderbussWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
-        for(int i = 0; i < 9; i++) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
+        for (int i = 0; i < 9; i++) {
             AbstractHurtingProjectile projectileEntity = this.getProjectile(shooter);
             double d0 = x - shooter.getX();
             double d1 = y + 0.5D - projectileEntity.getY();
@@ -245,7 +244,7 @@ public class BlunderbussWeapon implements IWeapon {
         }
 
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
 }

--- a/src/main/java/com/talhanation/recruits/compat/CGMWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/CGMWeapon.java
@@ -1,6 +1,5 @@
 package com.talhanation.recruits.compat;
 
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.util.Mth;
@@ -74,12 +73,12 @@ public class CGMWeapon implements IWeapon {
     public boolean isCrossBow() { return false; }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractArrow projectileEntity = this.getProjectileArrow(shooter);
         this.shootArrow(shooter, projectileEntity, x, y, z);
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F);
         shooter.level().addFreshEntity(projectileEntity);
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
     @Override

--- a/src/main/java/com/talhanation/recruits/compat/CrossbowWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/CrossbowWeapon.java
@@ -129,7 +129,7 @@ public class CrossbowWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractArrow projectileEntity = this.getProjectileArrow(shooter);
 		
         int i = EnchantmentHelper.getItemEnchantmentLevel(Enchantments.PIERCING, shooter.getMainHandItem());
@@ -147,12 +147,12 @@ public class CrossbowWeapon implements IWeapon {
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
         shooter.getCommandSenderWorld().addFreshEntity(projectileEntity);
 
-        if(RecruitsServerConfig.RangedRecruitsNeedArrowsToShoot.get()){
-            shooter.consumeArrow();
+        if (RecruitsServerConfig.RangedRecruitsNeedArrowsToShoot.get() && shooter instanceof AbstractRecruitEntity recruit) {
+            recruit.consumeArrow();
             projectileEntity.pickup = AbstractArrow.Pickup.ALLOWED;
         }
 
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
 
     }
 

--- a/src/main/java/com/talhanation/recruits/compat/IWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/IWeapon.java
@@ -1,5 +1,4 @@
 package com.talhanation.recruits.compat;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.projectile.AbstractArrow;
@@ -28,7 +27,7 @@ public interface IWeapon {
     boolean canMelee();
     boolean isBow();
     boolean isCrossBow();
-    void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed);
+    void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed);
 
     static boolean isMusketModWeapon(ItemStack stack){
         return stack.getDescriptionId().equals("item.musketmod.musket") ||

--- a/src/main/java/com/talhanation/recruits/compat/MusketBayonetWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/MusketBayonetWeapon.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.compat;
 
 import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.Mth;
@@ -237,19 +236,18 @@ public class MusketBayonetWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractHurtingProjectile projectileEntity = this.getProjectile(shooter);
         double d0 = x - shooter.getX();
         double d1 = y + 0.5D - projectileEntity.getY();
         double d2 = z - shooter.getZ();
-
 
         this.shoot(shooter, projectileEntity, d0, d1, d2);
 
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
         shooter.getCommandSenderWorld().addFreshEntity(projectileEntity);
 
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
 }

--- a/src/main/java/com/talhanation/recruits/compat/MusketScopeWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/MusketScopeWeapon.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.compat;
 
 import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.Mth;
@@ -236,19 +235,18 @@ public class MusketScopeWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractHurtingProjectile projectileEntity = this.getProjectile(shooter);
         double d0 = x - shooter.getX();
         double d1 = y + 0.5D - projectileEntity.getY();
         double d2 = z - shooter.getZ();
-
 
         this.shoot(shooter, projectileEntity, d0, d1, d2);
 
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
         shooter.getCommandSenderWorld().addFreshEntity(projectileEntity);
 
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
 }

--- a/src/main/java/com/talhanation/recruits/compat/MusketWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/MusketWeapon.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.compat;
 
 import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -235,19 +234,18 @@ public class MusketWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractHurtingProjectile projectileEntity = this.getProjectile(shooter);
         double d0 = x - shooter.getX();
         double d1 = y + 0.5D - projectileEntity.getY();
         double d2 = z - shooter.getZ();
-
 
         this.shoot(shooter, projectileEntity, d0, d1, d2);
 
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
         shooter.getCommandSenderWorld().addFreshEntity(projectileEntity);
 
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
 }

--- a/src/main/java/com/talhanation/recruits/compat/PistolWeapon.java
+++ b/src/main/java/com/talhanation/recruits/compat/PistolWeapon.java
@@ -1,7 +1,6 @@
 package com.talhanation.recruits.compat;
 
 import com.talhanation.recruits.Main;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
 
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvent;
@@ -237,7 +236,7 @@ public class PistolWeapon implements IWeapon {
     }
 
     @Override
-    public void performRangedAttackIWeapon(AbstractRecruitEntity shooter, double x, double y, double z, float projectileSpeed) {
+    public void performRangedAttackIWeapon(LivingEntity shooter, double x, double y, double z, float projectileSpeed) {
         AbstractHurtingProjectile projectileEntity = this.getProjectile(shooter);
         double d0 = x - shooter.getX();
         double d1 = y + 0.5D - projectileEntity.getY();
@@ -248,7 +247,7 @@ public class PistolWeapon implements IWeapon {
         shooter.playSound(this.getShootSound(), 1.0F, 1.0F / (shooter.getRandom().nextFloat() * 0.4F + 0.8F));
         shooter.getCommandSenderWorld().addFreshEntity(projectileEntity);
 
-        shooter.damageMainHandItem();
+        shooter.getMainHandItem().hurtAndBreak(1, shooter, (p) -> p.broadcastBreakEvent(net.minecraft.world.entity.EquipmentSlot.MAINHAND));
     }
 
 }

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedMusketAttackGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedMusketAttackGoal.java
@@ -1,0 +1,250 @@
+package com.talhanation.recruits.entities.ai.compat;
+
+import com.talhanation.recruits.compat.BlunderbussWeapon;
+import com.talhanation.recruits.compat.CGMWeapon;
+import com.talhanation.recruits.compat.IWeapon;
+import com.talhanation.recruits.compat.MusketBayonetWeapon;
+import com.talhanation.recruits.compat.MusketScopeWeapon;
+import com.talhanation.recruits.compat.MusketWeapon;
+import com.talhanation.recruits.compat.PistolWeapon;
+import com.talhanation.recruits.entities.IRecruitEntity;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.PathfinderMob;
+import net.minecraft.world.entity.ai.goal.Goal;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.EnumSet;
+
+/**
+ * Musket attack goal for controlled mobs, reusing recruit musket logic.
+ */
+public class ControlledMobRangedMusketAttackGoal extends Goal {
+    private final PathfinderMob mob;
+    private LivingEntity target;
+    private IWeapon weapon;
+    private int weaponLoadTime;
+    private int seeTime;
+    private State state;
+    private final double stopRange;
+
+    public ControlledMobRangedMusketAttackGoal(PathfinderMob mob, double stopRange) {
+        this.mob = mob;
+        this.weapon = new MusketWeapon();
+        this.stopRange = stopRange;
+        this.setFlags(EnumSet.of(Flag.MOVE, Flag.LOOK));
+    }
+
+    private boolean isActive() {
+        CompoundTag nbt = mob.getPersistentData();
+        IRecruitEntity recruit = IRecruitEntity.of(mob);
+        if (!nbt.getBoolean("RecruitControlled") || !recruit.isOwned())
+            return false;
+        if (nbt.getBoolean("ShouldRest"))
+            return false;
+        if (!nbt.getBoolean("ShouldRanged"))
+            return false;
+        return nbt.getInt("AggroState") != 3;
+    }
+
+    @Override
+    public boolean canUse() {
+        if (!isActive()) return false;
+        LivingEntity t = mob.getTarget();
+        if (t != null && t.isAlive() && isWeaponInHand()) {
+            return t.distanceTo(mob) >= stopRange;
+        }
+        CompoundTag nbt = mob.getPersistentData();
+        return nbt.getBoolean("ShouldStrategicFire") || (isWeaponInHand() && weapon != null && !weapon.isLoaded(mob.getMainHandItem()));
+    }
+
+    @Override
+    public boolean canContinueToUse() {
+        if (!isActive()) return false;
+        return canUse();
+    }
+
+    @Override
+    public void start() {
+        mob.setAggressive(true);
+        this.state = State.IDLE;
+        this.weaponLoadTime = weapon.getWeaponLoadTime();
+    }
+
+    @Override
+    public void stop() {
+        this.seeTime = 0;
+        this.weaponLoadTime = 0;
+        mob.stopUsingItem();
+        mob.setAggressive(false);
+    }
+
+    protected boolean isWeaponInHand() {
+        ItemStack itemStack = mob.getItemBySlot(EquipmentSlot.MAINHAND);
+        String id = itemStack.getDescriptionId();
+        if (id.equals("item.musketmod.musket")) {
+            this.weapon = new MusketWeapon();
+            return true;
+        } else if (id.equals("item.musketmod.musket_with_bayonet")) {
+            this.weapon = new MusketBayonetWeapon();
+            return true;
+        } else if (id.equals("item.musketmod.musket_with_scope")) {
+            this.weapon = new MusketScopeWeapon();
+            return true;
+        } else if (id.equals("item.musketmod.blunderbuss")) {
+            this.weapon = new BlunderbussWeapon();
+            return true;
+        } else if (id.equals("item.musketmod.pistol")) {
+            this.weapon = new PistolWeapon();
+            return true;
+        } else if (IWeapon.isCGMWeapon(itemStack)) {
+            this.weapon = new CGMWeapon();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void tick() {
+        target = mob.getTarget();
+        CompoundTag nbt = mob.getPersistentData();
+        BlockPos strategicPos = null;
+        if (nbt.getBoolean("ShouldStrategicFire")) {
+            strategicPos = new BlockPos(nbt.getInt("StrategicFireX"), nbt.getInt("StrategicFireY"), nbt.getInt("StrategicFireZ"));
+        }
+
+        if (!isWeaponInHand()) return;
+
+        if (target != null && target.isAlive()) {
+            boolean canSee = mob.getSensing().hasLineOfSight(target);
+            if (canSee) {
+                ++this.seeTime;
+            } else {
+                this.seeTime = 0;
+            }
+
+            switch (state) {
+                case IDLE -> {
+                    mob.setAggressive(false);
+                    State newState;
+                    if (!weapon.isLoaded(mob.getMainHandItem())) {
+                        newState = canLoad() ? State.RELOAD : State.IDLE;
+                    } else if (seeTime > 0) {
+                        newState = State.AIMING;
+                    } else {
+                        newState = State.IDLE;
+                    }
+                    this.state = newState;
+                }
+                case RELOAD -> {
+                    mob.startUsingItem(InteractionHand.MAIN_HAND);
+                    int i = mob.getTicksUsingItem();
+                    if (i >= this.weaponLoadTime) {
+                        mob.releaseUsingItem();
+                        mob.playSound(this.weapon.getLoadSound(), 1.0F, 1.0F / (mob.getRandom().nextFloat() * 0.4F + 0.8F));
+                        this.weapon.setLoaded(mob.getMainHandItem(), true);
+                        this.consumeAmmo();
+                        state = State.AIMING;
+                    }
+                }
+                case AIMING -> {
+                    mob.getLookControl().setLookAt(target, 30.0F, 30.0F);
+                    mob.setAggressive(true);
+                    this.seeTime++;
+                    if (this.seeTime >= 15 + mob.getRandom().nextInt(15)) {
+                        this.seeTime = 0;
+                        this.state = State.SHOOT;
+                    }
+                }
+                case SHOOT -> {
+                    mob.getLookControl().setLookAt(target, 30.0F, 30.0F);
+                    this.weapon.performRangedAttackIWeapon(mob, target.getX(), target.getY(), target.getZ(), weapon.getProjectileSpeed());
+                    this.weapon.setLoaded(mob.getMainHandItem(), false);
+                    this.state = canLoad() ? State.RELOAD : State.IDLE;
+                }
+            }
+        } else if (strategicPos != null) {
+            switch (state) {
+                case IDLE -> {
+                    mob.setAggressive(false);
+                    State newState;
+                    if (!weapon.isLoaded(mob.getMainHandItem())) {
+                        newState = canLoad() ? State.RELOAD : State.IDLE;
+                    } else {
+                        newState = State.AIMING;
+                    }
+                    this.state = newState;
+                }
+                case RELOAD -> {
+                    mob.startUsingItem(InteractionHand.MAIN_HAND);
+                    int i = mob.getTicksUsingItem();
+                    if (i >= this.weaponLoadTime) {
+                        mob.releaseUsingItem();
+                        mob.playSound(this.weapon.getLoadSound(), 1.0F, 1.0F / (mob.getRandom().nextFloat() * 0.4F + 0.8F));
+                        this.weapon.setLoaded(mob.getMainHandItem(), true);
+                        this.consumeAmmo();
+                        state = State.AIMING;
+                    }
+                }
+                case AIMING -> {
+                    mob.getLookControl().setLookAt(Vec3.atCenterOf(strategicPos));
+                    mob.setAggressive(true);
+                    this.seeTime++;
+                    if (this.seeTime >= 15 + mob.getRandom().nextInt(15)) {
+                        this.seeTime = 0;
+                        this.state = State.SHOOT;
+                    }
+                }
+                case SHOOT -> {
+                    mob.getLookControl().setLookAt(Vec3.atCenterOf(strategicPos));
+                    this.weapon.performRangedAttackIWeapon(mob, strategicPos.getX(), strategicPos.getY(), strategicPos.getZ(), weapon.getProjectileSpeed());
+                    this.weapon.setLoaded(mob.getMainHandItem(), false);
+                    this.state = canLoad() ? State.RELOAD : State.IDLE;
+                }
+            }
+        }
+    }
+
+    private void consumeAmmo() {
+        CompoundTag data = mob.getPersistentData();
+        if (!data.contains("MobInventory")) return;
+        ListTag list = data.getList("MobInventory", 10);
+        for (int i = 0; i < list.size(); i++) {
+            CompoundTag ct = list.getCompound(i);
+            ItemStack stack = ItemStack.of(ct);
+            if (stack.getDescriptionId().equals("item.musketmod.cartridge")) {
+                stack.shrink(1);
+                if (stack.isEmpty()) {
+                    list.remove(i);
+                } else {
+                    stack.save(ct);
+                }
+                data.put("MobInventory", list);
+                break;
+            }
+        }
+    }
+
+    private boolean canLoad() {
+        CompoundTag data = mob.getPersistentData();
+        if (!data.contains("MobInventory")) return false;
+        ListTag list = data.getList("MobInventory", 10);
+        for (int i = 0; i < list.size(); i++) {
+            ItemStack stack = ItemStack.of(list.getCompound(i));
+            if (stack.getDescriptionId().equals("item.musketmod.cartridge")) return true;
+        }
+        return false;
+    }
+
+    private enum State {
+        IDLE,
+        RELOAD,
+        AIMING,
+        SHOOT
+    }
+}


### PR DESCRIPTION
## Summary
- add ControlledMobRangedMusketAttackGoal to let controlled mobs fire muskets using shared ammo
- detect musket weapons in applyControlledMobGoals and attach new goal
- broaden weapon API to operate on LivingEntity so controlled mobs can shoot

## Testing
- `./gradlew build` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68956d1bb3d083278424fd6ee78b91df