### PR TITLE
Add XP and kill tracking for controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -347,6 +347,7 @@ public class CommandEvents {
             CompoundTag data = mob.getPersistentData();
             if (data.contains("Xp")) nbt.putInt("Xp", data.getInt("Xp"));
             if (data.contains("Level")) nbt.putInt("Level", data.getInt("Level"));
+            if (data.contains("Kills")) nbt.putInt("Kills", data.getInt("Kills"));
             if (data.contains("Moral")) nbt.putFloat("Moral", data.getFloat("Moral"));
             if (data.contains("Hunger")) nbt.putFloat("Hunger", data.getFloat("Hunger"));
             Main.SIMPLE_CHANNEL.send(PacketDistributor.PLAYER.with(() -> serverPlayer), new MessageControlledMobStats(nbt));

--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -5,7 +5,9 @@ import com.talhanation.recruits.config.RecruitsServerConfig;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.ICompanion;
 import com.talhanation.recruits.entities.IRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitMob;
 import com.talhanation.recruits.entities.MessengerEntity;
+import com.talhanation.recruits.entities.MobRecruit;
 import com.talhanation.recruits.entities.ai.horse.HorseRiddenByRecruitGoal;
 import com.talhanation.recruits.init.ModEntityTypes;
 import com.talhanation.recruits.inventory.PromoteContainer;
@@ -36,7 +38,9 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.animal.Animal;
 import net.minecraft.world.entity.animal.horse.AbstractChestedHorse;
 import net.minecraft.world.entity.animal.horse.AbstractHorse;
+import net.minecraft.world.entity.animal.IronGolem;
 import net.minecraft.world.entity.monster.AbstractIllager;
+import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.InteractionResult;
@@ -49,6 +53,8 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
+import net.minecraft.world.entity.boss.wither.WitherBoss;
 import net.minecraft.nbt.ListTag;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobFollowOwnerGoal;
 import com.talhanation.recruits.entities.ai.compat.ControlledMobHoldPosGoal;
@@ -308,6 +314,17 @@ public class RecruitEvents {
                 recruit.addXp(2);
                 recruit.checkLevel();
             }
+        } else if (owner instanceof Mob mob && !(mob instanceof AbstractRecruitEntity) && mob.getPersistentData().getBoolean("RecruitControlled")) {
+            if (!canAttack(mob, impactLiving)) {
+                event.setImpactResult(ProjectileImpactEvent.ImpactResult.SKIP_ENTITY);
+                return;
+            } else {
+                IRecruitMob recruit = IRecruitMob.of(mob);
+                if (recruit instanceof MobRecruit mr) {
+                    mr.addXp(2);
+                    mr.checkLevel();
+                }
+            }
         }
 
         if (owner instanceof AbstractIllager illager && !RecruitsServerConfig.PillagerFriendlyFire.get()) {
@@ -381,6 +398,20 @@ public class RecruitEvents {
 
         Entity target = event.getEntity();
         Entity source = event.getSource().getEntity();
+        if (target instanceof Mob mobTarget && !(mobTarget instanceof AbstractRecruitEntity) && mobTarget.getPersistentData().getBoolean("RecruitControlled")) {
+            IRecruitMob recruit = IRecruitMob.of(mobTarget);
+            if (recruit instanceof MobRecruit mr) {
+                mr.addXp(1);
+                mr.checkLevel();
+            }
+        }
+        if (source instanceof Mob mobSource && !(mobSource instanceof AbstractRecruitEntity) && mobSource.getPersistentData().getBoolean("RecruitControlled")) {
+            IRecruitMob recruit = IRecruitMob.of(mobSource);
+            if (recruit instanceof MobRecruit mr) {
+                mr.addXp(2);
+                mr.checkLevel();
+            }
+        }
         if (source instanceof LivingEntity sourceEntity) {
             if (target.getTeam() == null) return;
 
@@ -881,6 +912,36 @@ public class RecruitEvents {
         CompoundTag nbt = mob.getPersistentData();
         if(nbt.getBoolean("RecruitControlled")) {
             dropControlledMobInventory(mob);
+        }
+    }
+
+    @SubscribeEvent
+    public void onControlledMobKill(LivingDeathEvent event) {
+        if (event.getEntity().level().isClientSide()) return;
+        Entity source = event.getSource().getEntity();
+        if (source instanceof Mob mob && !(mob instanceof AbstractRecruitEntity) && mob.getPersistentData().getBoolean("RecruitControlled")) {
+            IRecruitMob recruit = IRecruitMob.of(mob);
+            if (recruit instanceof MobRecruit mr) {
+                mr.addXp(5);
+                mr.setKills(mr.getKills() + 1);
+                LivingEntity victim = event.getEntity();
+                if (victim instanceof Player) {
+                    mr.addXp(45);
+                }
+                if (victim instanceof Raider) {
+                    mr.addXp(5);
+                }
+                if (victim instanceof WitherBoss) {
+                    mr.addXp(99);
+                }
+                if (victim instanceof IronGolem) {
+                    mr.addXp(49);
+                }
+                if (victim instanceof EnderDragon) {
+                    mr.addXp(999);
+                }
+                mr.checkLevel();
+            }
         }
     }
 

--- a/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
@@ -34,14 +34,17 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
 
     public static int xp;
     public static int level;
+    public static int kills;
     public static float morale;
     public static float hunger;
 
     private static final MutableComponent TEXT_PROMOTE = Component.translatable("gui.recruits.inv.text.promote");
     private static final MutableComponent TOOLTIP_PROMOTE = Component.translatable("gui.recruits.inv.tooltip.promote");
+    private static final MutableComponent TOOLTIP_DISABLED_PROMOTE = Component.translatable("gui.recruits.inv.tooltip.promote_disabled");
 
     private final Mob mob;
     private EditBox nameField;
+    private Button promoteButton;
 
     public MobRecruitScreen(ControlledMobMenu container, Inventory playerInventory, Component title) {
         super(RESOURCE_LOCATION, container, playerInventory, Component.literal(""), IRecruitEntity.of(container.getMob()));
@@ -63,16 +66,23 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
         addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos, 70, 20,
                 Component.literal("Commands"),
                 button -> CommandEvents.openCommandScreen(minecraft.player)));
-        Button promoteButton = addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos + 24, 70, 20,
+        promoteButton = addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos + 24, 70, 20,
                 TEXT_PROMOTE,
                 btn -> RecruitEvents.openControlledMobPromoteScreen(minecraft.player, mob)));
-        promoteButton.setTooltip(Tooltip.create(TOOLTIP_PROMOTE));
+        boolean canPromote = level >= 3;
+        promoteButton.setTooltip(Tooltip.create(canPromote ? TOOLTIP_PROMOTE : TOOLTIP_DISABLED_PROMOTE));
+        promoteButton.active = canPromote;
     }
 
     @Override
     protected void containerTick() {
         super.containerTick();
         if (nameField != null) nameField.tick();
+        if (promoteButton != null) {
+            boolean canPromote = level >= 3;
+            promoteButton.active = canPromote;
+            promoteButton.setTooltip(Tooltip.create(canPromote ? TOOLTIP_PROMOTE : TOOLTIP_DISABLED_PROMOTE));
+        }
     }
 
     @Override
@@ -93,6 +103,8 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
         guiGraphics.drawString(font, String.valueOf((int) morale), k + gap, l + 20, fontColor, false);
         guiGraphics.drawString(font, "Hunger:", k, l + 30, fontColor, false);
         guiGraphics.drawString(font, String.valueOf((int) hunger), k + gap, l + 30, fontColor, false);
+        guiGraphics.drawString(font, "Kills:", k, l + 40, fontColor, false);
+        guiGraphics.drawString(font, String.valueOf(kills), k + gap, l + 40, fontColor, false);
         guiGraphics.pose().popPose();
     }
 

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -46,6 +46,9 @@ public class MobRecruit implements IRecruitMob {
     private static final String KEY_UPKEEP_POS_X = "UpkeepPosX";
     private static final String KEY_UPKEEP_POS_Y = "UpkeepPosY";
     private static final String KEY_UPKEEP_POS_Z = "UpkeepPosZ";
+    private static final String KEY_XP = "Xp";
+    private static final String KEY_LEVEL = "Level";
+    private static final String KEY_KILLS = "Kills";
 
     private final Mob mob;
     private final SimpleContainer inventory = new SimpleContainer(15);
@@ -194,6 +197,45 @@ public class MobRecruit implements IRecruitMob {
 
     public void setMountTimer(int timer) {
         setInt(KEY_MOUNT_TIMER, timer);
+    }
+
+    public int getXp() {
+        return getInt(KEY_XP);
+    }
+
+    public void setXp(int xp) {
+        setInt(KEY_XP, xp);
+    }
+
+    public int getXpLevel() {
+        return getInt(KEY_LEVEL);
+    }
+
+    public void setXpLevel(int level) {
+        setInt(KEY_LEVEL, level);
+    }
+
+    public void addXp(int xp) {
+        setXp(getXp() + xp);
+    }
+
+    public void addXpLevel(int level) {
+        setXpLevel(getXpLevel() + level);
+    }
+
+    public int getKills() {
+        return getInt(KEY_KILLS);
+    }
+
+    public void setKills(int kills) {
+        setInt(KEY_KILLS, kills);
+    }
+
+    public void checkLevel() {
+        if (getXp() >= RecruitsServerConfig.RecruitsMaxXpForLevelUp.get()) {
+            addXpLevel(1);
+            setXp(0);
+        }
     }
 
     @Nullable

--- a/src/main/java/com/talhanation/recruits/network/MessageControlledMobStats.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageControlledMobStats.java
@@ -27,6 +27,7 @@ public class MessageControlledMobStats implements Message<MessageControlledMobSt
         if (nbt == null) return;
         MobRecruitScreen.level = nbt.getInt("Level");
         MobRecruitScreen.xp = nbt.getInt("Xp");
+        MobRecruitScreen.kills = nbt.getInt("Kills");
         MobRecruitScreen.morale = nbt.getFloat("Moral");
         MobRecruitScreen.hunger = nbt.getFloat("Hunger");
     }


### PR DESCRIPTION
## Summary
- Track XP, level and kill stats for controlled mobs via persistent NBT
- Display real stats in Mob Recruit screen and disable promotions until level 3
- Award XP and kills for controlled mob combat actions

## Testing
- `./gradlew test` *(fails: NoClassDefFoundError in tests)*
- `./gradlew build` *(fails: tests failing)*
- `./gradlew check` *(fails: tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68956d1b13208327a3be19a6c5638154