### PR TITLE
Keep mob recruit inventories synced with NBT

### DIFF
--- a/src/main/java/com/talhanation/recruits/CommandEvents.java
+++ b/src/main/java/com/talhanation/recruits/CommandEvents.java
@@ -342,6 +342,9 @@ public class CommandEvents {
 
     public static void openMobInventoryScreen(Player player, Mob mob){
         if(player instanceof ServerPlayer serverPlayer){
+            if (!(mob instanceof IRecruitMob)) {
+                MobRecruit.get(mob).reloadInventory();
+            }
             updateRecruitInventoryScreen(serverPlayer);
             CompoundTag nbt = new CompoundTag();
             CompoundTag data = mob.getPersistentData();

--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -6,6 +6,8 @@ import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import com.talhanation.recruits.entities.ICompanion;
 import com.talhanation.recruits.entities.IRecruitEntity;
 import com.talhanation.recruits.entities.MessengerEntity;
+import com.talhanation.recruits.entities.IRecruitMob;
+import com.talhanation.recruits.entities.MobRecruit;
 import com.talhanation.recruits.entities.ai.horse.HorseRiddenByRecruitGoal;
 import com.talhanation.recruits.init.ModEntityTypes;
 import com.talhanation.recruits.inventory.PromoteContainer;
@@ -1085,6 +1087,9 @@ public class RecruitEvents {
                 if(data.contains(key)) tag.put(key, data.get(key).copy());
             }
         }
+        if (!(mob instanceof IRecruitMob)) {
+            MobRecruit.get(mob).reloadInventory();
+        }
     }
 
     private static ItemStack getOrEmpty(ItemStack[] arr, int idx) {
@@ -1141,6 +1146,9 @@ public class RecruitEvents {
             }
         }
         tag.put("MobInventory", list);
+        if (!(mob instanceof IRecruitMob)) {
+            MobRecruit.get(mob).reloadInventory();
+        }
     }
 
     public static void applyCompanionProfession(Mob mob) {

--- a/src/main/java/com/talhanation/recruits/entities/IRecruitEntity.java
+++ b/src/main/java/com/talhanation/recruits/entities/IRecruitEntity.java
@@ -38,7 +38,7 @@ public interface IRecruitEntity {
      * interface directly while other mobs are wrapped in a {@link MobRecruit}.
      */
     static IRecruitEntity of(Mob mob) {
-        return mob instanceof IRecruitEntity r ? r : new MobRecruit(mob);
+        return mob instanceof IRecruitEntity r ? r : MobRecruit.get(mob);
     }
 }
 

--- a/src/main/java/com/talhanation/recruits/entities/IRecruitMob.java
+++ b/src/main/java/com/talhanation/recruits/entities/IRecruitMob.java
@@ -96,7 +96,7 @@ public interface IRecruitMob extends IRecruitEntity {
      * in a {@link MobRecruit} adapter.
      */
     static IRecruitMob of(Mob mob) {
-        return mob instanceof IRecruitMob r ? r : new MobRecruit(mob);
+        return mob instanceof IRecruitMob r ? r : MobRecruit.get(mob);
     }
 }
 

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -3,6 +3,8 @@ package com.talhanation.recruits.inventory;
 import com.mojang.datafixers.util.Pair;
 import com.talhanation.recruits.init.ModScreens;
 import com.talhanation.recruits.inventory.RecruitInventoryMenu;
+import com.talhanation.recruits.entities.IRecruitMob;
+import com.talhanation.recruits.entities.MobRecruit;
 import de.maxhenkel.corelib.inventory.ContainerBase;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -106,6 +108,9 @@ public class ControlledMobMenu extends ContainerBase {
         mob.setItemSlot(EquipmentSlot.FEET, mobInventory.getItem(3));
         mob.setItemSlot(EquipmentSlot.OFFHAND, mobInventory.getItem(4));
         mob.setItemSlot(EquipmentSlot.MAINHAND, mobInventory.getItem(5));
+        if (!(mob instanceof IRecruitMob)) {
+            MobRecruit.get(mob).reloadInventory();
+        }
     }
 
     public ControlledMobMenu(int id, Mob mob, Inventory playerInventory){


### PR DESCRIPTION
## Summary
- Load mob recruit inventory from `MobInventory` NBT and persist updates
- Reuse cached mob recruit wrappers and resync them when NBT changes
- Refresh mob recruit inventory after GUI or NBT operations

## Testing
- `./gradlew build` *(fails: RecruitBehaviorTest failures)*
- `./gradlew test` *(fails: RecruitBehaviorTest failures)*
- `./gradlew check` *(fails: RecruitBehaviorTest failures)*

------
https://chatgpt.com/codex/tasks/task_e_68956d1e0bf083278a8ed2fe7265ff08