### PR TITLE
fix: prevent formation crash when non-recruit mobs included

### DIFF
--- a/src/main/java/com/talhanation/recruits/util/FormationUtils.java
+++ b/src/main/java/com/talhanation/recruits/util/FormationUtils.java
@@ -142,7 +142,7 @@ public class FormationUtils {
             AbstractRecruitEntity recruit = mob instanceof AbstractRecruitEntity ar ? ar : null;
             Vec3 pos = null;
 
-            if (recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
+            if (recruit != null && recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
                 FormationPosition position = possiblePositions.get(recruit.formationPos);
                 position.isFree = false;
                 pos = position.position;
@@ -209,7 +209,7 @@ public class FormationUtils {
             AbstractRecruitEntity recruit = mob instanceof AbstractRecruitEntity ar ? ar : null;
             Vec3 pos = null;
 
-            if (recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
+            if (recruit != null && recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
                 FormationPosition position = possiblePositions.get(recruit.formationPos);
                 position.isFree = false;
                 pos = position.position;
@@ -269,7 +269,7 @@ public class FormationUtils {
             AbstractRecruitEntity recruit = mob instanceof AbstractRecruitEntity ar ? ar : null;
             Vec3 pos = null;
 
-            if (recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
+            if (recruit != null && recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
                 FormationPosition position = possiblePositions.get(recruit.formationPos);
                 position.isFree = false;
                 pos = position.position;
@@ -353,7 +353,7 @@ public class FormationUtils {
             AbstractRecruitEntity recruit = mob instanceof AbstractRecruitEntity ar ? ar : null;
             Vec3 pos = null;
 
-            if (recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
+            if (recruit != null && recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
                 FormationPosition position = possiblePositions.get(recruit.formationPos);
                 position.isFree = false;
                 pos = position.position;
@@ -426,7 +426,7 @@ public class FormationUtils {
             AbstractRecruitEntity recruit = mob instanceof AbstractRecruitEntity ar ? ar : null;
             Vec3 pos = null;
 
-            if (recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
+            if (recruit != null && recruit.formationPos >= 0 && recruit.formationPos < possiblePositions.size() && possiblePositions.get(recruit.formationPos).isFree) {
                 FormationPosition position = possiblePositions.get(recruit.formationPos);
                 position.isFree = false;
                 pos = position.position;


### PR DESCRIPTION
## Summary
- avoid null pointer when assigning formation positions to non-recruit mobs

## Testing
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew build` *(fails: tests failed)*
- `./gradlew check` *(fails: tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68957a1f818c8327b443bc24d5904b64