### PR TITLE
Fix duplicate buttons on mob recruit screen

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
@@ -93,6 +93,9 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
     @Override
     protected void init() {
         super.init();
+        // Remove existing widgets to prevent duplicates if the screen is reopened
+        clearWidgets();
+
         Component name = mob.getCustomName() != null ? mob.getCustomName() : mob.getName();
         nameField = new EditBox(font, leftPos + 5, topPos - 23, 90, 20, name);
         nameField.setValue(name.getString());
@@ -100,6 +103,7 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
         nameField.setBordered(true);
         addRenderableWidget(nameField);
         setInitialFocus(nameField);
+
         addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos, 70, 20,
                 Component.literal("Commands"),
                 button -> CommandEvents.openCommandScreen(minecraft.player)));


### PR DESCRIPTION
## Summary
- clear existing widgets during `MobRecruitScreen` initialization to prevent duplicate buttons

## Testing
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew build` *(fails: 7 tests failed)*
- `./gradlew check` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68958c51afc08327b07a145c2a7c6cc0