### PR TITLE
Use direct mob lookup for promotions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation fg.deobf("de.maxhenkel.corelib:corelib:1.20.1-1.0.0:api")
 }
 
 test {

--- a/src/main/java/com/talhanation/recruits/network/MessagePromoteControlledMob.java
+++ b/src/main/java/com/talhanation/recruits/network/MessagePromoteControlledMob.java
@@ -4,7 +4,9 @@ import com.talhanation.recruits.RecruitEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
@@ -33,13 +35,12 @@ public class MessagePromoteControlledMob implements Message<MessagePromoteContro
     @Override
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
-        player.getCommandSenderWorld().getEntitiesOfClass(
-                Mob.class,
-                player.getBoundingBox().inflate(16D),
-                m -> !(m instanceof AbstractRecruitEntity) &&
-                        m.getPersistentData().getBoolean("RecruitControlled") &&
-                        m.getUUID().equals(this.mobId)
-        ).forEach(m -> RecruitEvents.promoteControlledMob(m, profession, name, player));
+        Entity entity = ((ServerLevel) player.level()).getEntity(this.mobId);
+        if (entity instanceof Mob mob
+                && !(mob instanceof AbstractRecruitEntity)
+                && mob.getPersistentData().getBoolean("RecruitControlled")) {
+            RecruitEvents.promoteControlledMob(mob, profession, name, player);
+        }
     }
 
     @Override

--- a/src/test/java/com/talhanation/recruits/network/MessagePromoteControlledMobTest.java
+++ b/src/test/java/com/talhanation/recruits/network/MessagePromoteControlledMobTest.java
@@ -1,0 +1,59 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.RecruitEvents;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraftforge.network.NetworkEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+public class MessagePromoteControlledMobTest {
+
+    @Test
+    public void testPromoteRegardlessOfDistance() {
+        UUID id = UUID.randomUUID();
+        MessagePromoteControlledMob msg = new MessagePromoteControlledMob(id, 1, "Bob");
+
+        NetworkEvent.Context ctx = mock(NetworkEvent.Context.class);
+        ServerPlayer player = mock(ServerPlayer.class);
+        ServerLevel level = mock(ServerLevel.class);
+        Mob mob = mock(Mob.class);
+        CompoundTag tag = new CompoundTag();
+        tag.putBoolean("RecruitControlled", true);
+
+        when(ctx.getSender()).thenReturn(player);
+        when(player.level()).thenReturn(level);
+        when(level.getEntity(id)).thenReturn(mob);
+        when(mob.getPersistentData()).thenReturn(tag);
+
+        try (MockedStatic<RecruitEvents> events = mockStatic(RecruitEvents.class)) {
+            msg.executeServerSide(ctx);
+            events.verify(() -> RecruitEvents.promoteControlledMob(mob, 1, "Bob", player));
+        }
+    }
+
+    @Test
+    public void testNoPromotionWhenEntityMissing() {
+        UUID id = UUID.randomUUID();
+        MessagePromoteControlledMob msg = new MessagePromoteControlledMob(id, 1, "Bob");
+
+        NetworkEvent.Context ctx = mock(NetworkEvent.Context.class);
+        ServerPlayer player = mock(ServerPlayer.class);
+        ServerLevel level = mock(ServerLevel.class);
+
+        when(ctx.getSender()).thenReturn(player);
+        when(player.level()).thenReturn(level);
+        when(level.getEntity(id)).thenReturn(null);
+
+        try (MockedStatic<RecruitEvents> events = mockStatic(RecruitEvents.class)) {
+            msg.executeServerSide(ctx);
+            events.verifyNoInteractions();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Promote controlled mobs by looking up entities directly by UUID
- Add tests covering promotion lookup and missing entity cases
- Include corelib API for test compilation

## Testing
- `./gradlew test` *(fails: NoClassDefFoundError and Mockito errors)*
- `./gradlew check` *(fails: NoClassDefFoundError and Mockito errors)*
- `./gradlew build` *(fails: NoClassDefFoundError and Mockito errors)*

------
https://chatgpt.com/codex/tasks/task_e_68958c502d248327b5791422e7e78ca5