### PR TITLE
Respect AggroState when targeting controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -494,6 +494,10 @@ public class RecruitEvents {
                 if (mob instanceof PathfinderMob pathfinderMob) {
                     applyControlledMobGoals(pathfinderMob);
                 }
+                if(!nbt.contains("AggroState")) {
+                    // ensure older controlled mobs default to neutral behaviour
+                    nbt.putInt("AggroState", 0);
+                }
                 applyCompanionProfession(mob);
             }
         }
@@ -1118,12 +1122,18 @@ public class RecruitEvents {
 
             @Override
             public boolean canUse() {
-                return mob.getPersistentData().getInt("AggroState") != 3 && goal.canUse();
+                int state = mob.getPersistentData().getInt("AggroState");
+                if (state == 3) return false;                     // passive
+                if (state == 0 && mob.getTarget() == null) return false; // neutral: react only
+                return goal.canUse();
             }
 
             @Override
             public boolean canContinueToUse() {
-                return mob.getPersistentData().getInt("AggroState") != 3 && goal.canContinueToUse();
+                int state = mob.getPersistentData().getInt("AggroState");
+                if (state == 3) return false;
+                if (state == 0 && mob.getTarget() == null) return false;
+                return goal.canContinueToUse();
             }
 
             @Override

--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobTargetGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobTargetGoal.java
@@ -12,4 +12,18 @@ public class ControlledMobTargetGoal extends NearestAttackableTargetGoal<LivingE
     public ControlledMobTargetGoal(PathfinderMob mob) {
         super(mob, LivingEntity.class, 10, true, false, target -> RecruitEvents.canAttack(mob, target));
     }
+
+    @Override
+    public boolean canUse() {
+        int state = this.mob.getPersistentData().getInt("AggroState");
+        if (state != 1 && state != 2) return false; // only free target when aggressive or raid
+        return super.canUse();
+    }
+
+    @Override
+    public boolean canContinueToUse() {
+        int state = this.mob.getPersistentData().getInt("AggroState");
+        if (state != 1 && state != 2) return false;
+        return super.canContinueToUse();
+    }
 }


### PR DESCRIPTION
## Summary
- Prevent controlled mobs from freely targeting unless AggroState is aggressive or raid
- Neutral mobs now only attack reactively and passive mobs never attack
- Reinitialize legacy controlled mobs with a default neutral AggroState

## Testing
- `./gradlew test` *(fails: 7 tests failed)*
- `./gradlew build -x test`


------
https://chatgpt.com/codex/tasks/task_e_68958c4ea78c8327a6498e69a86973d5