### PR TITLE
Refresh controlled mob goals after inventory change

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedMusketAttackGoal.java
+++ b/src/main/java/com/talhanation/recruits/entities/ai/compat/ControlledMobRangedMusketAttackGoal.java
@@ -18,6 +18,8 @@ import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.phys.Vec3;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraftforge.registries.ForgeRegistries;
 
 import java.util.EnumSet;
 
@@ -86,20 +88,21 @@ public class ControlledMobRangedMusketAttackGoal extends Goal {
 
     protected boolean isWeaponInHand() {
         ItemStack itemStack = mob.getItemBySlot(EquipmentSlot.MAINHAND);
-        String id = itemStack.getDescriptionId();
-        if (id.equals("item.musketmod.musket")) {
+        ResourceLocation key = ForgeRegistries.ITEMS.getKey(itemStack.getItem());
+        String id = key != null ? key.toString() : "";
+        if (id.equals("musketmod:musket")) {
             this.weapon = new MusketWeapon();
             return true;
-        } else if (id.equals("item.musketmod.musket_with_bayonet")) {
+        } else if (id.equals("musketmod:musket_with_bayonet")) {
             this.weapon = new MusketBayonetWeapon();
             return true;
-        } else if (id.equals("item.musketmod.musket_with_scope")) {
+        } else if (id.equals("musketmod:musket_with_scope")) {
             this.weapon = new MusketScopeWeapon();
             return true;
-        } else if (id.equals("item.musketmod.blunderbuss")) {
+        } else if (id.equals("musketmod:blunderbuss")) {
             this.weapon = new BlunderbussWeapon();
             return true;
-        } else if (id.equals("item.musketmod.pistol")) {
+        } else if (id.equals("musketmod:pistol")) {
             this.weapon = new PistolWeapon();
             return true;
         } else if (IWeapon.isCGMWeapon(itemStack)) {

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -5,6 +5,7 @@ import com.talhanation.recruits.init.ModScreens;
 import com.talhanation.recruits.inventory.RecruitInventoryMenu;
 import com.talhanation.recruits.entities.IRecruitMob;
 import com.talhanation.recruits.entities.MobRecruit;
+import com.talhanation.recruits.RecruitEvents;
 import de.maxhenkel.corelib.inventory.ContainerBase;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -13,6 +14,7 @@ import net.minecraft.world.Container;
 import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.PathfinderMob;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.InventoryMenu;
@@ -110,6 +112,9 @@ public class ControlledMobMenu extends ContainerBase {
         mob.setItemSlot(EquipmentSlot.MAINHAND, mobInventory.getItem(5));
         if (!(mob instanceof IRecruitMob)) {
             MobRecruit.get(mob).reloadInventory();
+        }
+        if (mob instanceof PathfinderMob pathfinderMob) {
+            RecruitEvents.refreshControlledMobGoals(pathfinderMob);
         }
     }
 


### PR DESCRIPTION
## Summary
- Re-evaluate controlled mob attack goals whenever inventory slots change
- Detect muskets by registry name for more reliable goal selection
- Use registry names inside musket attack goal for consistent musket animation triggers

## Testing
- `./gradlew test` *(fails: org.mockito.exceptions.base.MockitoException; java.lang.NoClassDefFoundError)*
- `./gradlew check` *(fails: org.mockito.exceptions.base.MockitoException; java.lang.NoClassDefFoundError)*
- `./gradlew build` *(fails: org.mockito.exceptions.base.MockitoException; java.lang.NoClassDefFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68958d623f908327a4904cb13e778abb