### PR TITLE
Position promote button below other controls

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
@@ -107,14 +107,15 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
         addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos, 70, 20,
                 Component.literal("Commands"),
                 button -> CommandEvents.openCommandScreen(minecraft.player)));
-        promoteButton = addRenderableWidget(new ExtendedButton(leftPos + imageWidth + 5, topPos + 24, 70, 20,
-                TEXT_PROMOTE,
-                btn -> RecruitEvents.openControlledMobPromoteScreen(minecraft.player, mob)));
-        promoteButton.setTooltip(Tooltip.create(TOOLTIP_PROMOTE));
 
         int zeroLeftPos = leftPos + 180;
         int zeroTopPos = topPos + 10;
         int topPosGab = 5;
+
+        promoteButton = addRenderableWidget(new ExtendedButton(zeroLeftPos, zeroTopPos + (20 + topPosGab) * 8, 80, 20,
+                TEXT_PROMOTE,
+                btn -> RecruitEvents.openControlledMobPromoteScreen(minecraft.player, mob)));
+        promoteButton.setTooltip(Tooltip.create(TOOLTIP_PROMOTE));
 
         ExtendedButton buttonPassive = new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGab) * 0, 80, 20, TEXT_PASSIVE,
                 btn -> {


### PR DESCRIPTION
## Summary
- Align the MobRecruitScreen promote button with the zeroLeftPos/zeroTopPos offset system so it sits below the right column controls.

## Testing
- `./gradlew build` *(fails: 10 tests failed)*
- `./gradlew test` *(fails: 10 tests failed)*
- `./gradlew check` *(fails: 10 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6896b1f5c86c83278b2fa42bdde16ae6