### PR TITLE
Align hold follow state and expand follow GUI targeting

### DIFF
--- a/src/main/java/com/talhanation/recruits/network/MessageFollowGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageFollowGui.java
@@ -2,12 +2,14 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.CommandEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.IRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
-import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,13 +31,15 @@ public class MessageFollowGui implements Message<MessageFollowGui> {
     }
 
     public void executeServerSide(NetworkEvent.Context context) {
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(16.0D));
-
-        for (AbstractRecruitEntity recruit : list) {
-            if (recruit.getUUID().equals(this.uuid) && recruit.isEffectedByCommand(context.getSender().getUUID(), 0)){
-                CommandEvents.onMovementCommandGUI(recruit, this.state);
-            }
-        }
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        player.getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
+                player.getBoundingBox().inflate(16.0D),
+                m -> m.getUUID().equals(this.uuid) && (
+                        m instanceof AbstractRecruitEntity recruit
+                                ? recruit.isEffectedByCommand(player.getUUID(), 0)
+                                : m.getPersistentData().getBoolean("RecruitControlled"))
+        ).forEach(m -> CommandEvents.onMovementCommandGUI(IRecruitEntity.of(m), this.state));
     }
 
     public MessageFollowGui fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
+++ b/src/main/java/com/talhanation/recruits/util/MobRecruitHandler.java
@@ -63,22 +63,22 @@ public class MobRecruitHandler implements RecruitHandler {
             String name = mob.getName().getString();
             int state = nbt.getInt("FollowState");
             switch (state) {
-                // default includes 0,2,3,5,... -> switch to follow
+                // default includes 0,3,4,5,... -> switch to follow
                 default -> {
                     nbt.putInt("FollowState", 1);
                     clearHoldPos(nbt);
                     player.sendSystemMessage(Component.translatable("chat.recruits.text.follow", name));
                 }
-                // follow -> hold at player position
+                // follow -> hold at current mob position
                 case 1 -> {
-                    nbt.putInt("FollowState", 4);
-                    nbt.putDouble("HoldX", player.getX());
-                    nbt.putDouble("HoldY", player.getY());
-                    nbt.putDouble("HoldZ", player.getZ());
+                    nbt.putInt("FollowState", 2);
+                    nbt.putDouble("HoldX", mob.getX());
+                    nbt.putDouble("HoldY", mob.getY());
+                    nbt.putDouble("HoldZ", mob.getZ());
                     player.sendSystemMessage(Component.translatable("chat.recruits.text.holdPos", name));
                 }
                 // hold -> wander
-                case 4 -> {
+                case 2 -> {
                     nbt.putInt("FollowState", 0);
                     clearHoldPos(nbt);
                     player.sendSystemMessage(Component.translatable("chat.recruits.text.wander", name));


### PR DESCRIPTION
## Summary
- Cycle wander, follow, and hold states using IDs 0→1→2 for controlled mobs
- Allow Follow GUI packets to command any mob with RecruitControlled NBT

## Testing
- `./gradlew build` *(fails: 10 tests failed)*
- `./gradlew test` *(fails: 10 tests failed)*
- `./gradlew check` *(fails: 10 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6896b1f6605c8327b4cb985e47db1ac5