### PR TITLE
Use projectile weapon ammo lookup for recruit bow goal

### DIFF
--- a/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
+++ b/src/main/java/com/talhanation/recruits/config/RecruitsServerConfig.java
@@ -73,6 +73,7 @@ public class RecruitsServerConfig {
     public static ForgeConfigSpec.BooleanValue UniversalMobControl;
     public static ForgeConfigSpec.BooleanValue ReplaceMobAI;
     public static ForgeConfigSpec.ConfigValue<List<String>> AdditionalGunItems;
+    public static ForgeConfigSpec.ConfigValue<List<String>> AdditionalAmmoItems;
     public static ForgeConfigSpec.BooleanValue PerMobCurrency;
     public static ForgeConfigSpec.ConfigValue<List<String>> MobCurrencyMap;
     public static ForgeConfigSpec.ConfigValue<List<String>> ControlledMobIds;
@@ -752,6 +753,14 @@ public class RecruitsServerConfig {
                         \tdefault: []""")
                 .worldRestart()
                 .define("AdditionalGunItems", new ArrayList<>());
+
+        AdditionalAmmoItems = BUILDER.comment("""
+                        Additional ammo items from other mods treated as valid ammunition.
+                        Provide a list of item registry names.
+                        \t(takes effect after restart)
+                        \tdefault: []""")
+                .worldRestart()
+                .define("AdditionalAmmoItems", new ArrayList<>());
 
         PerMobCurrency = BUILDER.comment("""
                         Use different hire currency for specific mobs. If false, uses global RecruitCurrency.


### PR DESCRIPTION
## Summary
- Use `ProjectileWeaponItem.getHeldProjectile` to detect ammo for projectile weapons
- Add fallback detection for firearms ammo including new `AdditionalAmmoItems` config list

## Testing
- `./gradlew test` *(fails: 10 tests failed)*
- `./gradlew build -x test`


------
https://chatgpt.com/codex/tasks/task_e_6896b1f741bc83278d516919039f8b1c