### PR TITLE
Preserve equipment when restoring mob inventory

### DIFF
--- a/src/main/java/com/talhanation/recruits/RecruitEvents.java
+++ b/src/main/java/com/talhanation/recruits/RecruitEvents.java
@@ -1234,12 +1234,12 @@ public class RecruitEvents {
                 extra[slot] = ItemStack.of(ct);
             }
         }
-        mob.setItemSlot(EquipmentSlot.HEAD, getOrEmpty(extra,0));
-        mob.setItemSlot(EquipmentSlot.CHEST, getOrEmpty(extra,1));
-        mob.setItemSlot(EquipmentSlot.LEGS, getOrEmpty(extra,2));
-        mob.setItemSlot(EquipmentSlot.FEET, getOrEmpty(extra,3));
-        mob.setItemSlot(EquipmentSlot.OFFHAND, getOrEmpty(extra,4));
-        mob.setItemSlot(EquipmentSlot.MAINHAND, getOrEmpty(extra,5));
+        if (extra[0] != null) mob.setItemSlot(EquipmentSlot.HEAD, extra[0]);
+        if (extra[1] != null) mob.setItemSlot(EquipmentSlot.CHEST, extra[1]);
+        if (extra[2] != null) mob.setItemSlot(EquipmentSlot.LEGS, extra[2]);
+        if (extra[3] != null) mob.setItemSlot(EquipmentSlot.FEET, extra[3]);
+        if (extra[4] != null) mob.setItemSlot(EquipmentSlot.OFFHAND, extra[4]);
+        if (extra[5] != null) mob.setItemSlot(EquipmentSlot.MAINHAND, extra[5]);
         if(tag.contains("MobData")){
             CompoundTag data = tag.getCompound("MobData");
             for(String key : ControlledMobMenu.EXTRA_KEYS){
@@ -1249,10 +1249,6 @@ public class RecruitEvents {
         if (!(mob instanceof IRecruitMob)) {
             MobRecruit.get(mob).reloadInventory();
         }
-    }
-
-    private static ItemStack getOrEmpty(ItemStack[] arr, int idx) {
-        return idx >= 0 && idx < arr.length && arr[idx] != null ? arr[idx] : ItemStack.EMPTY;
     }
 
     public static void dropControlledMobInventory(Mob mob) {

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -90,7 +90,7 @@ public class ControlledMobMenu extends ContainerBase {
     private void saveInventory(){
         CompoundTag tag = mob.getPersistentData();
         ListTag list = new ListTag();
-        for(int i=6;i<mobInventory.getContainerSize();i++){
+        for(int i=0;i<mobInventory.getContainerSize();i++){
             ItemStack stack = mobInventory.getItem(i);
             if(!stack.isEmpty()){
                 CompoundTag ct = new CompoundTag();


### PR DESCRIPTION
## Summary
- avoid overwriting mob equipment when no inventory NBT exists
- store equipment slots when saving a controlled mob

## Testing
- `./gradlew build` *(fails: 10 tests completed, 10 failed)*
- `./gradlew test` *(fails: 10 tests completed, 10 failed)*
- `./gradlew check` *(fails: 10 tests completed, 10 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6896b5328a488327853235b2ecdff4b3