### PR TITLE
Replicate follow state logic in mob formation adapter

### DIFF
--- a/src/main/java/com/talhanation/recruits/util/MobFormationAdapter.java
+++ b/src/main/java/com/talhanation/recruits/util/MobFormationAdapter.java
@@ -1,13 +1,24 @@
 package com.talhanation.recruits.util;
 
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.TamableAnimal;
 import net.minecraft.world.phys.Vec3;
 
 /**
  * Adapter for generic mobs to participate in formations using persistent NBT fields.
  */
 public class MobFormationAdapter implements FormationMember {
+    private static final String KEY_HOLD_X = "HoldX";
+    private static final String KEY_HOLD_Y = "HoldY";
+    private static final String KEY_HOLD_Z = "HoldZ";
+    private static final String KEY_SHOULD_HOLD_POS = "ShouldHoldPos";
+    private static final String KEY_SHOULD_FOLLOW = "ShouldFollow";
+    private static final String KEY_SHOULD_PROTECT = "ShouldProtect";
+    private static final String KEY_SHOULD_MOVE_POS = "ShouldMovePos";
+    private static final String KEY_FOLLOW_STATE = "FollowState";
+
     private final Mob mob;
 
     public MobFormationAdapter(Mob mob) {
@@ -22,13 +33,69 @@ public class MobFormationAdapter implements FormationMember {
     @Override
     public void setHoldPos(Vec3 pos) {
         CompoundTag nbt = mob.getPersistentData();
-        nbt.putDouble("HoldX", pos.x);
-        nbt.putDouble("HoldY", pos.y);
-        nbt.putDouble("HoldZ", pos.z);
+        nbt.putDouble(KEY_HOLD_X, pos.x);
+        nbt.putDouble(KEY_HOLD_Y, pos.y);
+        nbt.putDouble(KEY_HOLD_Z, pos.z);
     }
 
     @Override
     public void setFollowState(int state) {
-        mob.getPersistentData().putInt("FollowState", state);
+        CompoundTag nbt = mob.getPersistentData();
+        switch (state) {
+            case 0, 6 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, false);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, false);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, false);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+            }
+            case 1 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, true);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, false);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, false);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+            }
+            case 2 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, false);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, true);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, false);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+                Vec3 pos = mob.position();
+                nbt.remove(KEY_HOLD_X);
+                nbt.remove(KEY_HOLD_Y);
+                nbt.remove(KEY_HOLD_Z);
+                setHoldPos(pos);
+            }
+            case 3 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, false);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, true);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, false);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+            }
+            case 4 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, false);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, true);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, false);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+                Vec3 pos = mob.position();
+                if (mob instanceof TamableAnimal tamable) {
+                    LivingEntity owner = tamable.getOwner();
+                    if (owner != null) {
+                        pos = owner.position();
+                    }
+                }
+                nbt.remove(KEY_HOLD_X);
+                nbt.remove(KEY_HOLD_Y);
+                nbt.remove(KEY_HOLD_Z);
+                setHoldPos(pos);
+                state = 3;
+            }
+            case 5 -> {
+                nbt.putBoolean(KEY_SHOULD_FOLLOW, false);
+                nbt.putBoolean(KEY_SHOULD_HOLD_POS, false);
+                nbt.putBoolean(KEY_SHOULD_PROTECT, true);
+                nbt.putBoolean(KEY_SHOULD_MOVE_POS, false);
+            }
+        }
+        nbt.putInt(KEY_FOLLOW_STATE, state);
     }
 }


### PR DESCRIPTION
## Summary
- expand MobFormationAdapter to mirror AbstractRecruitEntity.setFollowState
- write ShouldHoldPos, ShouldFollow, ShouldProtect, and ShouldMovePos flags to NBT
- reset HoldX/HoldY/HoldZ when switching to hold states, using owner position for state 4

## Testing
- `./gradlew test` *(fails: 10 tests)*
- `./gradlew check` *(fails: there were failing tests)*
- `./gradlew build` *(fails: there were failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6897421c934883278787cafa7e543f2d