### PR TITLE
Generalize disband and assignment for controlled mobs

### DIFF
--- a/src/main/java/com/talhanation/recruits/client/gui/DisbandScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/DisbandScreen.java
@@ -4,7 +4,7 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.talhanation.recruits.Main;
 import com.talhanation.recruits.client.gui.player.PlayersList;
 import com.talhanation.recruits.client.gui.player.SelectPlayerScreen;
-import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import net.minecraft.world.entity.Mob;
 import com.talhanation.recruits.network.MessageAssignGroupToTeamMate;
 import com.talhanation.recruits.network.MessageAssignToTeamMate;
 import com.talhanation.recruits.network.MessageDisband;
@@ -13,7 +13,6 @@ import de.maxhenkel.corelib.inventory.ScreenBase;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
-import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.renderer.GameRenderer;
 import net.minecraft.network.chat.Component;
@@ -27,7 +26,7 @@ public class DisbandScreen extends RecruitsScreenBase {
     private static final ResourceLocation TEXTURE = new ResourceLocation(Main.MOD_ID, "textures/gui/gui_big.png");
     private static final Component TITLE = Component.translatable("gui.recruits.more_screen.title");
     private Player player;
-    private AbstractRecruitEntity recruit;
+    private Mob recruit;
     private static final MutableComponent DISBAND = Component.translatable("gui.recruits.inv.text.disband");
     private static final MutableComponent DISBAND_GROUP = Component.translatable("gui.recruits.inv.text.disbandGroup");
     private static final MutableComponent TOOLTIP_DISBAND = Component.translatable("gui.recruits.inv.tooltip.disband");
@@ -38,7 +37,7 @@ public class DisbandScreen extends RecruitsScreenBase {
     private static final MutableComponent TEAM_MATE = Component.translatable("gui.recruits.team.assignNewOwner");
     private static final MutableComponent TEAM_MATE_GROUP = Component.translatable("gui.recruits.team.assignGroupNewOwner");
 
-    public DisbandScreen(Screen parent, AbstractRecruitEntity recruit, Player player) {
+    public DisbandScreen(Screen parent, Mob recruit, Player player) {
         super(TITLE, 195,160);
         this.player = player;
         this.recruit = recruit;

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -45,8 +45,6 @@ public class MobRecruit implements IRecruitMob {
     private static final String KEY_SHOULD_MOVE_POS = "ShouldMovePos";
     private static final String KEY_FLEEING = "Fleeing";
     private static final String KEY_SHOULD_MOUNT = "ShouldMount";
-    private static final String KEY_SHOULD_MOVE_POS = "ShouldMovePos";
-    private static final String KEY_SHOULD_PROTECT = "ShouldProtect";
     private static final String KEY_SHOULD_BLOCK = "ShouldBlock";
     private static final String KEY_SHOULD_REST = "ShouldRest";
     private static final String KEY_SHOULD_RANGED = "ShouldRanged";

--- a/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToTeamMate.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignGroupToTeamMate.java
@@ -2,9 +2,11 @@ package com.talhanation.recruits.network;
 
 import com.talhanation.recruits.TeamEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.MobRecruit;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -33,24 +35,45 @@ public class MessageAssignGroupToTeamMate implements Message<MessageAssignGroupT
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = Objects.requireNonNull(context.getSender());
-        List<AbstractRecruitEntity> list = serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
+        List<Mob> list = serverPlayer.getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
                 context.getSender().getBoundingBox().inflate(100D),
-                (recruit) -> recruit.getOwnerUUID() != null && recruit.getOwnerUUID().equals(owner)
+                mob -> {
+                    if (mob instanceof AbstractRecruitEntity r) {
+                        UUID u = r.getOwnerUUID();
+                        return u != null && u.equals(owner);
+                    }
+                    if (mob.getPersistentData().getBoolean("RecruitControlled")) {
+                        UUID u = MobRecruit.get(mob).getOwnerUUID();
+                        return u != null && u.equals(owner);
+                    }
+                    return false;
+                }
         );
         int group = -1;
 
-        for (AbstractRecruitEntity recruit1 : list){
-            if(recruit1.getUUID().equals(recruit)){
-                group = recruit1.getGroup();
+        for (Mob mob : list){
+            if(mob.getUUID().equals(recruit)){
+                if (mob instanceof AbstractRecruitEntity r) {
+                    group = r.getGroup();
+                } else {
+                    group = MobRecruit.get(mob).getGroup();
+                }
                 break;
             }
         }
 
-        for (AbstractRecruitEntity recruit : list) {
-            UUID recruitOwner = recruit.getOwnerUUID();
-            if (recruitOwner != null && recruitOwner.equals(owner) && recruit.getGroup() == group)
-                TeamEvents.assignToTeamMate(serverPlayer, newOwner, recruit);
+        for (Mob mob : list) {
+            if (mob instanceof AbstractRecruitEntity recruitEntity) {
+                UUID recruitOwner = recruitEntity.getOwnerUUID();
+                if (recruitOwner != null && recruitOwner.equals(owner) && recruitEntity.getGroup() == group)
+                    TeamEvents.assignToTeamMate(serverPlayer, newOwner, recruitEntity);
+            } else {
+                MobRecruit recruit = MobRecruit.get(mob);
+                UUID recruitOwner = recruit.getOwnerUUID();
+                if (recruitOwner != null && recruitOwner.equals(owner) && recruit.getGroup() == group)
+                    TeamEvents.assignToTeamMate(serverPlayer, newOwner, mob);
+            }
         }
     }
     public MessageAssignGroupToTeamMate fromBytes(FriendlyByteBuf buf) {

--- a/src/main/java/com/talhanation/recruits/network/MessageAssignToTeamMate.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAssignToTeamMate.java
@@ -5,6 +5,7 @@ import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -31,11 +32,15 @@ public class MessageAssignToTeamMate implements Message<MessageAssignToTeamMate>
 
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer serverPlayer = context.getSender();
-        List<AbstractRecruitEntity> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(AbstractRecruitEntity.class, context.getSender().getBoundingBox().inflate(64.0D));
+        List<Mob> list = Objects.requireNonNull(context.getSender()).getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
+                context.getSender().getBoundingBox().inflate(64.0D),
+                mob -> mob instanceof AbstractRecruitEntity || mob.getPersistentData().getBoolean("RecruitControlled")
+        );
 
-        for (AbstractRecruitEntity recruit : list) {
-            if(recruit.getUUID().equals(this.recruit)){
-                TeamEvents.assignToTeamMate(serverPlayer, newOwner, recruit);
+        for (Mob mob : list) {
+            if (mob.getUUID().equals(this.recruit)) {
+                TeamEvents.assignToTeamMate(serverPlayer, newOwner, mob);
                 break;
             }
         }

--- a/src/main/java/com/talhanation/recruits/network/MessageDisband.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageDisband.java
@@ -1,9 +1,14 @@
 package com.talhanation.recruits.network;
 
+import com.talhanation.recruits.RecruitEvents;
+import com.talhanation.recruits.TeamEvents;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.MobRecruit;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Mob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
 
@@ -30,10 +35,29 @@ public class MessageDisband implements Message<MessageDisband> {
     public void executeServerSide(NetworkEvent.Context context) {
         ServerPlayer player = Objects.requireNonNull(context.getSender());
         player.getCommandSenderWorld().getEntitiesOfClass(
-                AbstractRecruitEntity.class,
+                Mob.class,
                 player.getBoundingBox().inflate(16D),
-                (recruit) -> recruit.getUUID().equals(this.recruit)
-        ).forEach((recruit) -> recruit.disband(context.getSender(), keepTeam, true));
+                (mob) -> mob.getUUID().equals(this.recruit) &&
+                        (mob instanceof AbstractRecruitEntity || mob.getPersistentData().getBoolean("RecruitControlled"))
+        ).forEach(mob -> disband(mob, player, keepTeam));
+    }
+
+    private static void disband(Mob mob, ServerPlayer player, boolean keepTeam) {
+        if (mob instanceof AbstractRecruitEntity recruit) {
+            recruit.disband(player, keepTeam, true);
+        } else {
+            MobRecruit recruit = MobRecruit.get(mob);
+            UUID owner = recruit.getOwnerUUID();
+            if (owner != null) {
+                RecruitEvents.recruitsPlayerUnitManager.removeRecruits(owner, 1);
+            }
+            mob.setTarget(null);
+            recruit.setIsOwned(false);
+            recruit.setOwnerUUID(null);
+            if (!keepTeam && mob.getTeam() != null) {
+                TeamEvents.removeRecruitFromTeam(mob, mob.getTeam(), (ServerLevel) mob.level());
+            }
+        }
     }
 
     public MessageDisband fromBytes(FriendlyByteBuf buf) {


### PR DESCRIPTION
## Summary
- Allow Disband screen to target any Mob instead of only AbstractRecruitEntity
- Extend disband and assignment messages to operate on generic mobs via MobRecruit
- Add TeamEvents helper to reassign controlled mobs between teammates

## Testing
- `./gradlew test` *(fails: NoClassDefFoundError in tests)*
- `./gradlew build` *(fails: test failures)
- `./gradlew check` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68974c778980832782e8c919ecf5763f