### PR TITLE
Add combat flag controls for mob recruits

### DIFF
--- a/src/main/java/com/talhanation/recruits/Main.java
+++ b/src/main/java/com/talhanation/recruits/Main.java
@@ -124,6 +124,7 @@ public class Main {
                 MessageUpkeepPos.class,
                 MessageStrategicFire.class,
                 MessageShields.class,
+                MessageCombatFlagGui.class,
                 MessageDebugGui.class,
                 MessageRenameMob.class,
                 MessageControlledMobGroup.class,

--- a/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
+++ b/src/main/java/com/talhanation/recruits/client/gui/MobRecruitScreen.java
@@ -13,6 +13,7 @@ import com.talhanation.recruits.network.MessageClearUpkeepGui;
 import com.talhanation.recruits.network.MessageControlledMobGroup;
 import com.talhanation.recruits.network.MessageDismountGui;
 import com.talhanation.recruits.network.MessageFollowGui;
+import com.talhanation.recruits.network.MessageCombatFlagGui;
 import com.talhanation.recruits.network.MessageListen;
 import com.talhanation.recruits.network.MessageMountEntityGui;
 import com.talhanation.recruits.network.MessageRenameMob;
@@ -260,6 +261,17 @@ public class MobRecruitScreen extends AbstractRecruitScreen<ControlledMobMenu> {
                 TEXT_BACK_TO_MOUNT,
                 btn -> Main.SIMPLE_CHANNEL.sendToServer(new MessageMountEntityGui(mob.getUUID(), true))));
         backToMount.setTooltip(Tooltip.create(TOOLTIP_BACK_TO_MOUNT));
+
+        int combatPos = zeroLeftPos + 90;
+        addRenderableWidget(new ExtendedButton(combatPos, zeroTopPos + (20 + topPosGab) * 0, 80, 20, Component.literal("Ranged"),
+                btn -> Main.SIMPLE_CHANNEL.sendToServer(new MessageCombatFlagGui(mob.getUUID(), 0,
+                        !mob.getPersistentData().getBoolean("ShouldRanged")))));
+        addRenderableWidget(new ExtendedButton(combatPos, zeroTopPos + (20 + topPosGab) * 1, 80, 20, Component.literal("Block"),
+                btn -> Main.SIMPLE_CHANNEL.sendToServer(new MessageCombatFlagGui(mob.getUUID(), 1,
+                        !mob.getPersistentData().getBoolean("ShouldBlock")))));
+        addRenderableWidget(new ExtendedButton(combatPos, zeroTopPos + (20 + topPosGab) * 2, 80, 20, Component.literal("Rest"),
+                btn -> Main.SIMPLE_CHANNEL.sendToServer(new MessageCombatFlagGui(mob.getUUID(), 2,
+                        !mob.getPersistentData().getBoolean("ShouldRest")))));
 
         this.clearUpkeep = addRenderableWidget(new ExtendedButton(zeroLeftPos - 270, zeroTopPos + (20 + topPosGab) * 6, 80, 20,
                 TEXT_CLEAR_UPKEEP,

--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -89,6 +89,9 @@ public class MobRecruit implements IRecruitMob {
             }
         };
         reloadInventory();
+        if (!mob.getPersistentData().contains(KEY_SHOULD_RANGED)) {
+            setBoolean(KEY_SHOULD_RANGED, true);
+        }
     }
 
     private CompoundTag data() {

--- a/src/main/java/com/talhanation/recruits/network/MessageCombatFlagGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageCombatFlagGui.java
@@ -1,0 +1,67 @@
+package com.talhanation.recruits.network;
+
+import com.talhanation.recruits.entities.AbstractRecruitEntity;
+import com.talhanation.recruits.entities.MobRecruit;
+import de.maxhenkel.corelib.net.Message;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public class MessageCombatFlagGui implements Message<MessageCombatFlagGui> {
+
+    private UUID uuid;
+    private int flag;
+    private boolean value;
+
+    public MessageCombatFlagGui() {
+    }
+
+    public MessageCombatFlagGui(UUID uuid, int flag, boolean value) {
+        this.uuid = uuid;
+        this.flag = flag;
+        this.value = value;
+    }
+
+    @Override
+    public Dist getExecutingSide() {
+        return Dist.DEDICATED_SERVER;
+    }
+
+    @Override
+    public void executeServerSide(NetworkEvent.Context context) {
+        ServerPlayer player = Objects.requireNonNull(context.getSender());
+        player.getCommandSenderWorld().getEntitiesOfClass(
+                Mob.class,
+                player.getBoundingBox().inflate(16.0D),
+                m -> m.getUUID().equals(this.uuid) &&
+                        (m instanceof AbstractRecruitEntity || m.getPersistentData().getBoolean("RecruitControlled"))
+        ).forEach(m -> {
+            MobRecruit recruit = MobRecruit.get(m);
+            switch (this.flag) {
+                case 0 -> recruit.setShouldRanged(this.value);
+                case 1 -> recruit.setShouldBlock(this.value);
+                case 2 -> recruit.setShouldRest(this.value);
+            }
+        });
+    }
+
+    @Override
+    public MessageCombatFlagGui fromBytes(FriendlyByteBuf buf) {
+        this.uuid = buf.readUUID();
+        this.flag = buf.readInt();
+        this.value = buf.readBoolean();
+        return this;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeUUID(uuid);
+        buf.writeInt(flag);
+        buf.writeBoolean(value);
+    }
+}


### PR DESCRIPTION
## Summary
- Default new mob recruits to use ranged attacks
- Add GUI buttons to toggle ranged, blocking, and resting behavior
- Implement and register `MessageCombatFlagGui` for these combat flags

## Testing
- `./gradlew build` *(fails: RecruitBehaviorTest > testXpLevelPersistence() etc.)*
- `./gradlew test` *(fails: RecruitBehaviorTest > testXpLevelPersistence() etc.)*
- `./gradlew check` *(fails: RecruitBehaviorTest > testXpLevelPersistence() etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689759d6ff2c8327ba1acbe3c411d309