### PR TITLE
Decouple mob equipment syncing from goal application

### DIFF
--- a/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
+++ b/src/main/java/com/talhanation/recruits/entities/MobRecruit.java
@@ -205,7 +205,15 @@ public class MobRecruit implements IRecruitMob {
             inventory.setItem(5, mob.getItemBySlot(EquipmentSlot.MAINHAND));
         }
         loading = false;
-        saveInventory();
+    }
+
+    public void syncEquipmentFromInventory() {
+        mob.setItemSlot(EquipmentSlot.HEAD, inventory.getItem(0));
+        mob.setItemSlot(EquipmentSlot.CHEST, inventory.getItem(1));
+        mob.setItemSlot(EquipmentSlot.LEGS, inventory.getItem(2));
+        mob.setItemSlot(EquipmentSlot.FEET, inventory.getItem(3));
+        mob.setItemSlot(EquipmentSlot.OFFHAND, inventory.getItem(4));
+        mob.setItemSlot(EquipmentSlot.MAINHAND, inventory.getItem(5));
     }
 
     // ---------------------------------------------------------------------

--- a/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
+++ b/src/main/java/com/talhanation/recruits/inventory/ControlledMobMenu.java
@@ -6,7 +6,6 @@ import com.talhanation.recruits.inventory.RecruitInventoryMenu;
 import com.talhanation.recruits.RecruitEvents;
 import com.talhanation.recruits.entities.IRecruitMob;
 import com.talhanation.recruits.entities.MobRecruit;
-import com.talhanation.recruits.RecruitEvents;
 import de.maxhenkel.corelib.inventory.ContainerBase;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
@@ -115,7 +114,7 @@ public class ControlledMobMenu extends ContainerBase {
             RecruitEvents.applyControlledMobGoals(pathfinderMob);
         }
         if (!(mob instanceof IRecruitMob)) {
-            MobRecruit.get(mob).reloadInventory();
+            MobRecruit.get(mob).syncEquipmentFromInventory();
         }
         if (mob instanceof PathfinderMob pathfinderMob) {
             RecruitEvents.refreshControlledMobGoals(pathfinderMob);


### PR DESCRIPTION
## Summary
- Stop MobRecruit.reloadInventory from persisting inventory
- Add MobRecruit.syncEquipmentFromInventory to apply inventory to equipment slots
- Sync controlled mobs without reloading inventory and refresh their goals once

## Testing
- `./gradlew build --console=plain` *(fails: 10 tests failed)*
- `./gradlew test --console=plain` *(fails: 10 tests failed)*
- `./gradlew check --console=plain` *(fails: 10 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689759d7ff7083279f225eb92d01aaf8