### PR TITLE
Sync mob flags with client

### DIFF
--- a/src/main/java/com/talhanation/recruits/Main.java
+++ b/src/main/java/com/talhanation/recruits/Main.java
@@ -197,7 +197,8 @@ public class Main {
                 MessageToServerRequestUpdatePlayerCurrencyCount.class,
                 MessageToClientUpdatePlayerCurrencyCount.class,
                 MessageToClientOpenTakeOverScreen.class,
-                MessageToClientOpenMessengerAnswerScreen.class
+                MessageToClientOpenMessengerAnswerScreen.class,
+                MessageSyncMobFlags.class
         };
 
 

--- a/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageAggroGui.java
@@ -1,5 +1,6 @@
 package com.talhanation.recruits.network;
 
+import com.talhanation.recruits.Main;
 import com.talhanation.recruits.entities.AbstractRecruitEntity;
 import de.maxhenkel.corelib.net.Message;
 import net.minecraft.network.FriendlyByteBuf;
@@ -8,6 +9,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.PathfinderMob;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.PacketDistributor;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -36,14 +38,27 @@ public class MessageAggroGui implements Message<MessageAggroGui> {
                 player.getBoundingBox().inflate(16.0D),
                 m -> m.getUUID().equals(this.uuid) && (m instanceof AbstractRecruitEntity || m.getPersistentData().getBoolean("RecruitControlled"))
         ).forEach(m -> {
+            int aggroState;
+            int followState;
+            boolean listen;
+
             if (m instanceof AbstractRecruitEntity recruit) {
                 recruit.setState(this.state);
+                aggroState = recruit.getState();
+                followState = recruit.getFollowState();
+                listen = recruit.getListen();
             } else {
                 m.getPersistentData().putInt("AggroState", this.state);
                 if (m instanceof PathfinderMob pm && this.state == 3) {
                     pm.setTarget(null);
                 }
+                aggroState = this.state;
+                followState = m.getPersistentData().getInt("FollowState");
+                listen = m.getPersistentData().getBoolean("Listen");
             }
+
+            Main.SIMPLE_CHANNEL.send(PacketDistributor.PLAYER.with(() -> player),
+                    new MessageSyncMobFlags(m.getUUID(), aggroState, followState, listen, m.getClass().getName()));
         });
     }
 

--- a/src/main/java/com/talhanation/recruits/network/MessageSyncMobFlags.java
+++ b/src/main/java/com/talhanation/recruits/network/MessageSyncMobFlags.java
@@ -1,0 +1,85 @@
+package com.talhanation.recruits.network;
+
+import de.maxhenkel.corelib.net.Message;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientLevel;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.UUID;
+
+/**
+ * Client-bound packet that mirrors selected persistent data flags for a mob.
+ * <p>
+ * The GUI reads these values directly from {@link Entity#getPersistentData()},
+ * so they must be kept in sync when the server updates them.
+ */
+public class MessageSyncMobFlags implements Message<MessageSyncMobFlags> {
+
+    private UUID uuid;
+    private int aggroState;
+    private int followState;
+    private boolean listen;
+    private String className;
+
+    public MessageSyncMobFlags() {
+    }
+
+    public MessageSyncMobFlags(UUID uuid, int aggroState, int followState, boolean listen, String className) {
+        this.uuid = uuid;
+        this.aggroState = aggroState;
+        this.followState = followState;
+        this.listen = listen;
+        this.className = className;
+    }
+
+    @Override
+    public Dist getExecutingSide() {
+        return Dist.CLIENT;
+    }
+
+    @Override
+    public void executeClientSide(NetworkEvent.Context context) {
+        Minecraft mc = Minecraft.getInstance();
+        ClientLevel level = mc.level;
+        if (level == null) {
+            return;
+        }
+        Entity entity = null;
+        for (Entity e : level.entitiesForRendering()) {
+            if (uuid.equals(e.getUUID())) {
+                entity = e;
+                break;
+            }
+        }
+        if (entity == null) {
+            return;
+        }
+        // Mirror updated flags into the entity's persistent data
+        entity.getPersistentData().putInt("AggroState", aggroState);
+        entity.getPersistentData().putInt("FollowState", followState);
+        entity.getPersistentData().putBoolean("Listen", listen);
+        entity.getPersistentData().putString("Class", className);
+    }
+
+    @Override
+    public MessageSyncMobFlags fromBytes(FriendlyByteBuf buf) {
+        this.uuid = buf.readUUID();
+        this.aggroState = buf.readInt();
+        this.followState = buf.readInt();
+        this.listen = buf.readBoolean();
+        this.className = buf.readUtf(32767);
+        return this;
+    }
+
+    @Override
+    public void toBytes(FriendlyByteBuf buf) {
+        buf.writeUUID(uuid);
+        buf.writeInt(aggroState);
+        buf.writeInt(followState);
+        buf.writeBoolean(listen);
+        buf.writeUtf(className);
+    }
+}


### PR DESCRIPTION
## Summary
- send MessageSyncMobFlags after aggro/follow GUI actions
- mirror mob flags client side so GUI updates immediately
- register new network packet

## Testing
- `./gradlew build` *(fails: 10 tests)*
- `./gradlew test` *(fails: 10 tests)*
- `./gradlew check` *(fails: 10 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68975e63b2cc832785ec5ddf19d8d3b9